### PR TITLE
Fix pyloncore addon name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ bukkit {
     main = "io.github.pylonmc.pylon.base.PylonBase"
     version = project.version.toString()
     apiVersion = "1.21"
-    depend = listOf("pylon-core")
+    depend = listOf("PylonCore")
 }
 
 tasks.runServer {


### PR DESCRIPTION
The latest pylon-core change causes the pylon-core dependency to fail and pylon-base stops working entirely, so this is a merge ASAP!!! have tested in-game, seems to fix everything and error no longer appears in console. Need to also run clearPaperCache, cleanPaperPluginsCache, clean and then rerun server after making the change