### PR TITLE
Add ferroduralum items

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ bukkit {
     main = "io.github.pylonmc.pylon.base.PylonBase"
     version = project.version.toString()
     apiVersion = "1.21"
-    depend = listOf("PylonCore")
+    depend = listOf("Pylon-Core")
 }
 
 tasks.runServer {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -255,7 +255,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_sword_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -288,7 +288,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_axe_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -321,7 +321,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_pickaxe_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -354,7 +354,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_shovel_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -387,7 +387,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_hoe_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -420,7 +420,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -452,7 +452,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -484,7 +484,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
@@ -516,7 +516,7 @@ public final class PylonItems {
                             ))
                             .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_durability"),
-                                    250,
+                                    250 * 1.15,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -7,6 +7,7 @@ import io.github.pylonmc.pylon.core.item.ItemStackBuilder;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
 import io.github.pylonmc.pylon.core.item.SimpleItemSchema;
 import io.github.pylonmc.pylon.core.item.SimplePylonItem;
+import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
 import io.github.pylonmc.pylon.core.util.MiningLevel;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.Consumable;
@@ -17,8 +18,12 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.recipe.CookingBookCategory;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -197,6 +202,292 @@ public final class PylonItems {
                     .set(DataComponentTypes.CONSUMABLE, Consumable.consumable().build())
                     .build()
     );
+
+    public static final PylonItemSchema FERRODURALUM_ORE = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_ore"),
+            new ItemStackBuilder(Material.IRON_ORE)
+                    .name("Ferroduralum ore")
+                    .lore("A crafting material to make",
+                            "armor, weapons and tools.")
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            ferroduralum -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_ore"), ferroduralum);
+                recipe.shape(
+                        "CIR",
+                        "   ",
+                        "   "
+                );
+                recipe.setIngredient('C', Material.COPPER_ORE);
+                recipe.setIngredient('I', Material.IRON_ORE);
+                recipe.setIngredient('R', Material.REDSTONE);
+                recipe.setCategory(CraftingBookCategory.MISC);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_INGOT = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_ingot"),
+            new ItemStackBuilder(Material.IRON_INGOT)
+                    .name("Ferroduralum ingot")
+                    .lore("A crafting material to make",
+                            "armor, weapons and tools.")
+                    .build(),
+            RecipeTypes.VANILLA_FURNACE,
+            ingot -> {
+                FurnaceRecipe recipe = new FurnaceRecipe(pylonKey("ferroduralum_ingot"), ingot, FERRODURALUM_ORE.getItemStack().getType(), 0.25f, 3 * 20);
+                recipe.setCategory(CookingBookCategory.MISC);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_SWORD = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_sword"),
+            new ItemStackBuilder(Material.IRON_SWORD)
+                    .name("Ferroduralum sword")
+                    .lore("A more powerful iron sword.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
+                                    pylonKey("ferroduralum_sword_damage"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            sword -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_sword"), sword);
+                recipe.shape(
+                        " F ",
+                        " F ",
+                        " S "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setIngredient('S', Material.STICK);
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_AXE = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_axe"),
+            new ItemStackBuilder(Material.IRON_AXE)
+                    .name("Ferroduralum axe")
+                    .lore("A more powerful iron axe")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_axe_speed"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            axe -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_axe"), axe);
+                recipe.shape(
+                        "FF ",
+                        "FS ",
+                        " S "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setIngredient('S', Material.STICK);
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_PICKAXE = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_pickaxe"),
+            new ItemStackBuilder(Material.IRON_PICKAXE)
+                    .name("Ferroduralum pickaxe")
+                    .lore("A more powerful iron pickaxe")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_pickaxe_speed"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            pick -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_pickaxe"), pick);
+                recipe.shape(
+                        "FFF",
+                        " S ",
+                        " S "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setIngredient('S', Material.STICK);
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_SHOVEL = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_shovel"),
+            new ItemStackBuilder(Material.IRON_SHOVEL)
+                    .name("Ferroduralum shovel")
+                    .lore("A more powerful iron shovel.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_shovel_speed"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            shovel -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_shovel"), shovel);
+                recipe.shape(
+                        " F ",
+                        " S ",
+                        " S "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setIngredient('S', Material.STICK);
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_HOE = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_hoe"),
+            new ItemStackBuilder(Material.IRON_HOE)
+                    .name("Ferroduralum hoe")
+                    .lore("A more powerful iron hoe.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_hoe_speed"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            hoe -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_hoe"), hoe);
+                recipe.shape(
+                        "FF ",
+                        " S ",
+                        " S "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setIngredient('S', Material.STICK);
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_HELMET = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_helmet"),
+            new ItemStackBuilder(Material.IRON_HELMET)
+                    .name("Ferroduralum helmet")
+                    .lore("A more powerful iron helmet.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_helmet_armor"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            helmet -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_helmet"), helmet);
+                recipe.shape(
+                        "FFF",
+                        "F F",
+                        "   "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_CHESTPLATE = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_chestplate"),
+            new ItemStackBuilder(Material.IRON_CHESTPLATE)
+                    .name("Ferroduralum chestplate")
+                    .lore("A more powerful iron chestplate.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_chestplate_armor"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            chestplate -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_chestplate"), chestplate);
+                recipe.shape(
+                        "F F",
+                        "FFF",
+                        "FFF"
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_LEGGINGS = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_leggings"),
+            new ItemStackBuilder(Material.IRON_LEGGINGS)
+                    .name("Ferroduralum leggings")
+                    .lore("More powerful iron leggings.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_leggings_armor"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            leggings -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_leggings"), leggings);
+                recipe.shape(
+                        "FFF",
+                        "F F",
+                        "F F"
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
+
+    public static final PylonItemSchema FERRODURALUM_BOOTS = new SimpleItemSchema<>(
+            pylonKey("ferroduralum_boots"),
+            new ItemStackBuilder(Material.IRON_BOOTS)
+                    .name("Ferroduralum boots")
+                    .lore("More powerful iron boots.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_boots_armor"),
+                                    1.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            boots -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_boots"), boots);
+                recipe.shape(
+                        "F F",
+                        "F F",
+                        "   "
+                );
+                recipe.setIngredient('F', FERRODURALUM_INGOT.getItemStack());
+                recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+                return recipe;
+            }
+    );
     //</editor-fold>
 
     static void register() {
@@ -208,6 +499,17 @@ public final class PylonItems {
         DIAMOND_HAMMER.register();
         MONSTER_JERKY.register();
         WATERING_CAN.register();
+        FERRODURALUM_ORE.register();
+        FERRODURALUM_INGOT.register();
+        FERRODURALUM_SWORD.register();
+        FERRODURALUM_AXE.register();
+        FERRODURALUM_PICKAXE.register();
+        FERRODURALUM_SHOVEL.register();
+        FERRODURALUM_HOE.register();
+        FERRODURALUM_HELMET.register();
+        FERRODURALUM_CHESTPLATE.register();
+        FERRODURALUM_LEGGINGS.register();
+        FERRODURALUM_BOOTS.register();
     }
 
     private static @NotNull NamespacedKey pylonKey(@NotNull String key) {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -633,12 +633,14 @@ public final class PylonItems {
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_armor"),
                                     2.5,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.HEAD
                             ))
                             .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_toughness"),
                                     1,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.HEAD
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
@@ -666,12 +668,14 @@ public final class PylonItems {
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_armor"),
                                     7,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.CHEST
                             ))
                             .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_toughness"),
                                     1,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.CHEST
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
@@ -699,12 +703,14 @@ public final class PylonItems {
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_armor"),
                                     5.5,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.LEGS
                             ))
                             .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_toughness"),
                                     1,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.LEGS
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
@@ -729,16 +735,17 @@ public final class PylonItems {
                     .name("Ferroduralum boots")
                     .lore("More powerful iron boots.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            // setting any attribute overrides the default only apply when equipped behavior
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_armor"),
                                     2.5,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.FEET
                             ))
                             .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_toughness"),
                                     1,
-                                    AttributeModifier.Operation.ADD_NUMBER
+                                    AttributeModifier.Operation.ADD_NUMBER,
+                                    EquipmentSlotGroup.FEET
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -22,7 +22,6 @@ import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
-import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
@@ -245,23 +244,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SWORD = new SimpleItemSchema<>(
             pylonKey("ferroduralum_sword"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_SWORD)
-                        .name("Ferroduralum sword")
-                        .lore("A more powerful iron sword.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
-                                        pylonKey("ferroduralum_sword_damage"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable itemmeta = (Damageable)item.getItemMeta();
-                itemmeta.setMaxDamage(300);
-                item.setItemMeta(itemmeta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_SWORD)
+                    .name("Ferroduralum sword")
+                    .lore("A more powerful iron sword.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
+                                    pylonKey("ferroduralum_sword_damage"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             sword -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_sword"), sword);
@@ -279,23 +273,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_AXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_axe"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_AXE)
-                        .name("Ferroduralum axe")
-                        .lore("A more powerful iron axe")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                        pylonKey("ferroduralum_axe_speed"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_AXE)
+                    .name("Ferroduralum axe")
+                    .lore("A more powerful iron axe")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_axe_speed"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             axe -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_axe"), axe);
@@ -313,23 +302,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_PICKAXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_pickaxe"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_PICKAXE)
-                        .name("Ferroduralum pickaxe")
-                        .lore("A more powerful iron pickaxe")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                        pylonKey("ferroduralum_pickaxe_speed"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_PICKAXE)
+                    .name("Ferroduralum pickaxe")
+                    .lore("A more powerful iron pickaxe")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_pickaxe_speed"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             pick -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_pickaxe"), pick);
@@ -347,23 +331,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SHOVEL = new SimpleItemSchema<>(
             pylonKey("ferroduralum_shovel"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_SHOVEL)
-                        .name("Ferroduralum shovel")
-                        .lore("A more powerful iron shovel.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                        pylonKey("ferroduralum_shovel_speed"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_SHOVEL)
+                    .name("Ferroduralum shovel")
+                    .lore("A more powerful iron shovel.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_shovel_speed"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             shovel -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_shovel"), shovel);
@@ -381,23 +360,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HOE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_hoe"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_HOE)
-                        .name("Ferroduralum hoe")
-                        .lore("A more powerful iron hoe.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                        pylonKey("ferroduralum_hoe_speed"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_HOE)
+                    .name("Ferroduralum hoe")
+                    .lore("A more powerful iron hoe.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                    pylonKey("ferroduralum_hoe_speed"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             hoe -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_hoe"), hoe);
@@ -415,23 +389,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HELMET = new SimpleItemSchema<>(
             pylonKey("ferroduralum_helmet"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_HELMET)
-                        .name("Ferroduralum helmet")
-                        .lore("A more powerful iron helmet.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                        pylonKey("ferroduralum_helmet_armor"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_HELMET)
+                    .name("Ferroduralum helmet")
+                    .lore("A more powerful iron helmet.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_helmet_armor"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             helmet -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_helmet"), helmet);
@@ -448,23 +417,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_CHESTPLATE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_chestplate"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_CHESTPLATE)
-                        .name("Ferroduralum chestplate")
-                        .lore("A more powerful iron chestplate.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                        pylonKey("ferroduralum_chestplate_armor"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_CHESTPLATE)
+                    .name("Ferroduralum chestplate")
+                    .lore("A more powerful iron chestplate.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_chestplate_armor"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             chestplate -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_chestplate"), chestplate);
@@ -481,23 +445,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_LEGGINGS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_leggings"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_LEGGINGS)
-                        .name("Ferroduralum leggings")
-                        .lore("More powerful iron leggings.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                        pylonKey("ferroduralum_leggings_armor"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_LEGGINGS)
+                    .name("Ferroduralum leggings")
+                    .lore("More powerful iron leggings.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_leggings_armor"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             leggings -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_leggings"), leggings);
@@ -514,23 +473,18 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_BOOTS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_boots"),
-            () -> {
-                ItemStack item = new ItemStackBuilder(Material.GOLDEN_BOOTS)
-                        .name("Ferroduralum boots")
-                        .lore("More powerful iron boots.")
-                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                                .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                        pylonKey("ferroduralum_boots_armor"),
-                                        0.15,
-                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                                ))
-                                .build())
-                        .build();
-                Damageable meta = (Damageable) item.getItemMeta();
-                meta.setMaxDamage(300);
-                item.setItemMeta(meta);
-                return item;
-            },
+            new ItemStackBuilder(Material.GOLDEN_BOOTS)
+                    .name("Ferroduralum boots")
+                    .lore("More powerful iron boots.")
+                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                    pylonKey("ferroduralum_boots_armor"),
+                                    0.15,
+                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .build())
+                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .build(),
             RecipeTypes.VANILLA_CRAFTING,
             boots -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_boots"), boots);

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -234,7 +234,7 @@ public final class PylonItems {
                     .build(),
             RecipeTypes.VANILLA_FURNACE,
             ingot -> {
-                FurnaceRecipe recipe = new FurnaceRecipe(pylonKey("ferroduralum_ingot"), ingot, FERRODURALUM_ORE.getItemStack().getType(), 0.25f, 10 * 20);
+                FurnaceRecipe recipe = new FurnaceRecipe(pylonKey("ferroduralum_ingot"), ingot, new RecipeChoice.ExactChoice(FERRODURALUM_ORE.getItemStack()), 0.25f, 10 * 20);
                 recipe.setCategory(CookingBookCategory.MISC);
                 return recipe;
             }

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -1,12 +1,6 @@
 package io.github.pylonmc.pylon.base;
 
-import io.github.pylonmc.pylon.base.items.Hammer;
-import io.github.pylonmc.pylon.base.items.MonsterJerky;
-import io.github.pylonmc.pylon.base.items.Sprinkler;
-import io.github.pylonmc.pylon.base.items.PortableDustbin;
-import io.github.pylonmc.pylon.base.items.PortableEnderChest;
-import io.github.pylonmc.pylon.base.items.PortableCraftingTable;
-import io.github.pylonmc.pylon.base.items.WateringCan;
+import io.github.pylonmc.pylon.base.items.*;
 import io.github.pylonmc.pylon.core.item.ItemStackBuilder;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
 import io.github.pylonmc.pylon.core.item.SimpleItemSchema;
@@ -14,24 +8,19 @@ import io.github.pylonmc.pylon.core.item.SimplePylonItem;
 import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
 import io.github.pylonmc.pylon.core.util.MiningLevel;
 import io.papermc.paper.datacomponent.DataComponentTypes;
-import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.datacomponent.item.Consumable;
 import io.papermc.paper.datacomponent.item.FoodProperties;
+import io.papermc.paper.datacomponent.item.ItemAdventurePredicate;
 import io.papermc.paper.datacomponent.item.ItemAttributeModifiers;
+import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.inventory.FurnaceRecipe;
-import org.bukkit.inventory.CraftingRecipe;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.RecipeChoice;
-import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.*;
 import org.bukkit.inventory.recipe.CookingBookCategory;
-import org.bukkit.inventory.recipe.CraftingBookCategory;
-import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
@@ -613,6 +602,7 @@ public final class PylonItems {
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
+                    .set(DataComponentTypes.CAN_PLACE_ON, ItemAdventurePredicate.itemAdventurePredicate().build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -638,8 +628,8 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                    6,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -253,6 +253,11 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_sword_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -280,6 +285,11 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_axe_speed"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_axe_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -309,6 +319,11 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_pickaxe_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -336,6 +351,11 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_shovel_speed"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_shovel_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -365,6 +385,11 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_hoe_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -393,6 +418,11 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_helmet_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -419,6 +449,11 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_chestplate_armor"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_chestplate_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -447,6 +482,11 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_leggings_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -473,6 +513,11 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_boots_armor"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                            ))
+                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
+                                    pylonKey("ferroduralum_boots_durability"),
+                                    250,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -235,7 +235,7 @@ public final class PylonItems {
                     .build(),
             RecipeTypes.VANILLA_FURNACE,
             ingot -> {
-                FurnaceRecipe recipe = new FurnaceRecipe(pylonKey("ferroduralum_ingot"), ingot, FERRODURALUM_ORE.getItemStack().getType(), 0.25f, 3 * 20);
+                FurnaceRecipe recipe = new FurnaceRecipe(pylonKey("ferroduralum_ingot"), ingot, FERRODURALUM_ORE.getItemStack().getType(), 0.25f, 10 * 20);
                 recipe.setCategory(CookingBookCategory.MISC);
                 return recipe;
             }

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.FurnaceRecipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
@@ -244,17 +245,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SWORD = new SimpleItemSchema<>(
             pylonKey("ferroduralum_sword"),
-            new ItemStackBuilder(Material.GOLDEN_SWORD)
-                    .name("Ferroduralum sword")
-                    .lore("A more powerful iron sword.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
-                                    pylonKey("ferroduralum_sword_damage"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_SWORD)
+                        .name("Ferroduralum sword")
+                        .lore("A more powerful iron sword.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
+                                        pylonKey("ferroduralum_sword_damage"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable itemmeta = (Damageable)item.getItemMeta();
+                itemmeta.setMaxDamage(300);
+                item.setItemMeta(itemmeta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             sword -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_sword"), sword);
@@ -272,17 +279,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_AXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_axe"),
-            new ItemStackBuilder(Material.GOLDEN_AXE)
-                    .name("Ferroduralum axe")
-                    .lore("A more powerful iron axe")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                    pylonKey("ferroduralum_axe_speed"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_AXE)
+                        .name("Ferroduralum axe")
+                        .lore("A more powerful iron axe")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                        pylonKey("ferroduralum_axe_speed"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             axe -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_axe"), axe);
@@ -300,17 +313,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_PICKAXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_pickaxe"),
-            new ItemStackBuilder(Material.GOLDEN_PICKAXE)
-                    .name("Ferroduralum pickaxe")
-                    .lore("A more powerful iron pickaxe")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                    pylonKey("ferroduralum_pickaxe_speed"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_PICKAXE)
+                        .name("Ferroduralum pickaxe")
+                        .lore("A more powerful iron pickaxe")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                        pylonKey("ferroduralum_pickaxe_speed"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             pick -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_pickaxe"), pick);
@@ -328,17 +347,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SHOVEL = new SimpleItemSchema<>(
             pylonKey("ferroduralum_shovel"),
-            new ItemStackBuilder(Material.GOLDEN_SHOVEL)
-                    .name("Ferroduralum shovel")
-                    .lore("A more powerful iron shovel.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                    pylonKey("ferroduralum_shovel_speed"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_SHOVEL)
+                        .name("Ferroduralum shovel")
+                        .lore("A more powerful iron shovel.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                        pylonKey("ferroduralum_shovel_speed"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             shovel -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_shovel"), shovel);
@@ -356,17 +381,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HOE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_hoe"),
-            new ItemStackBuilder(Material.GOLDEN_HOE)
-                    .name("Ferroduralum hoe")
-                    .lore("A more powerful iron hoe.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
-                                    pylonKey("ferroduralum_hoe_speed"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_HOE)
+                        .name("Ferroduralum hoe")
+                        .lore("A more powerful iron hoe.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
+                                        pylonKey("ferroduralum_hoe_speed"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             hoe -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_hoe"), hoe);
@@ -384,17 +415,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HELMET = new SimpleItemSchema<>(
             pylonKey("ferroduralum_helmet"),
-            new ItemStackBuilder(Material.GOLDEN_HELMET)
-                    .name("Ferroduralum helmet")
-                    .lore("A more powerful iron helmet.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                    pylonKey("ferroduralum_helmet_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_HELMET)
+                        .name("Ferroduralum helmet")
+                        .lore("A more powerful iron helmet.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                        pylonKey("ferroduralum_helmet_armor"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             helmet -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_helmet"), helmet);
@@ -411,17 +448,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_CHESTPLATE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_chestplate"),
-            new ItemStackBuilder(Material.GOLDEN_CHESTPLATE)
-                    .name("Ferroduralum chestplate")
-                    .lore("A more powerful iron chestplate.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                    pylonKey("ferroduralum_chestplate_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_CHESTPLATE)
+                        .name("Ferroduralum chestplate")
+                        .lore("A more powerful iron chestplate.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                        pylonKey("ferroduralum_chestplate_armor"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             chestplate -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_chestplate"), chestplate);
@@ -438,17 +481,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_LEGGINGS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_leggings"),
-            new ItemStackBuilder(Material.GOLDEN_LEGGINGS)
-                    .name("Ferroduralum leggings")
-                    .lore("More powerful iron leggings.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                    pylonKey("ferroduralum_leggings_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_LEGGINGS)
+                        .name("Ferroduralum leggings")
+                        .lore("More powerful iron leggings.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                        pylonKey("ferroduralum_leggings_armor"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             leggings -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_leggings"), leggings);
@@ -465,17 +514,23 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_BOOTS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_boots"),
-            new ItemStackBuilder(Material.GOLDEN_BOOTS)
-                    .name("Ferroduralum boots")
-                    .lore("More powerful iron boots.")
-                    .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
-                            .addModifier(Attribute.ARMOR, new AttributeModifier(
-                                    pylonKey("ferroduralum_boots_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .build())
-                    .build(),
+            () -> {
+                ItemStack item = new ItemStackBuilder(Material.GOLDEN_BOOTS)
+                        .name("Ferroduralum boots")
+                        .lore("More powerful iron boots.")
+                        .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                                .addModifier(Attribute.ARMOR, new AttributeModifier(
+                                        pylonKey("ferroduralum_boots_armor"),
+                                        0.15,
+                                        AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                ))
+                                .build())
+                        .build();
+                Damageable meta = (Damageable) item.getItemMeta();
+                meta.setMaxDamage(300);
+                item.setItemMeta(meta);
+                return item;
+            },
             RecipeTypes.VANILLA_CRAFTING,
             boots -> {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_boots"), boots);

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -253,11 +253,6 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_sword_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
-                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -285,11 +280,6 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_axe_speed"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_axe_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -319,11 +309,6 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_pickaxe_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
-                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -351,11 +336,6 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_shovel_speed"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_shovel_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -385,11 +365,6 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_hoe_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
-                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -418,11 +393,6 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_helmet_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
-                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -449,11 +419,6 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_chestplate_armor"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_chestplate_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),
@@ -482,11 +447,6 @@ public final class PylonItems {
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_leggings_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
-                            ))
                             .build())
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -513,11 +473,6 @@ public final class PylonItems {
                                     pylonKey("ferroduralum_boots_armor"),
                                     0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
-                            ))
-                            .addModifier(Attribute.MAX_HEALTH, new AttributeModifier(
-                                    pylonKey("ferroduralum_boots_durability"),
-                                    250 * 1.15,
-                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .build(),

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -11,19 +11,26 @@ import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.*;
 import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import net.kyori.adventure.util.TriState;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.block.BlockType;
 import org.bukkit.inventory.*;
+import org.bukkit.inventory.meta.ArmorMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 @SuppressWarnings("UnstableApiUsage")
 public final class PylonItems {
@@ -625,11 +632,15 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_armor"),
-                                    6,
+                                    2.5,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
+                            .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
+                                    pylonKey("ferroduralum_helmet_toughness"),
+                                    1,
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
-                    .set(DataComponentTypes.EQUIPPABLE, Equippable.equippable(EquipmentSlot.HEAD).build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
@@ -654,8 +665,13 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                    7,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
+                            .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
+                                    pylonKey("ferroduralum_chestplate_toughness"),
+                                    1,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
@@ -682,8 +698,13 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                    5.5,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
+                            .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
+                                    pylonKey("ferroduralum_leggings_toughness"),
+                                    1,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
@@ -708,10 +729,16 @@ public final class PylonItems {
                     .name("Ferroduralum boots")
                     .lore("More powerful iron boots.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
+                            // setting any attribute overrides the default only apply when equipped behavior
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_armor"),
-                                    0.15,
-                                    AttributeModifier.Operation.MULTIPLY_SCALAR_1
+                                    2.5,
+                                    AttributeModifier.Operation.ADD_NUMBER
+                            ))
+                            .addModifier(Attribute.ARMOR_TOUGHNESS, new AttributeModifier(
+                                    pylonKey("ferroduralum_boots_toughness"),
+                                    1,
+                                    AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -8,10 +8,7 @@ import io.github.pylonmc.pylon.core.item.SimplePylonItem;
 import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
 import io.github.pylonmc.pylon.core.util.MiningLevel;
 import io.papermc.paper.datacomponent.DataComponentTypes;
-import io.papermc.paper.datacomponent.item.Consumable;
-import io.papermc.paper.datacomponent.item.FoodProperties;
-import io.papermc.paper.datacomponent.item.ItemAdventurePredicate;
-import io.papermc.paper.datacomponent.item.ItemAttributeModifiers;
+import io.papermc.paper.datacomponent.item.*;
 import io.papermc.paper.datacomponent.item.consumable.ConsumeEffect;
 import io.papermc.paper.datacomponent.item.consumable.ItemUseAnimation;
 import org.bukkit.Material;
@@ -632,6 +629,7 @@ public final class PylonItems {
                                     AttributeModifier.Operation.ADD_NUMBER
                             ))
                             .build())
+                    .set(DataComponentTypes.EQUIPPABLE, Equippable.equippable(EquipmentSlot.HEAD).build())
                     .set(DataComponentTypes.MAX_DAMAGE, 300)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -18,7 +18,10 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.FurnaceRecipe;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
@@ -206,8 +209,6 @@ public final class PylonItems {
                     .name("Ferroduralum ore")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
-                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
-                    .set(DataComponentTypes.RARITY, ItemRarity.EPIC)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             ferroduralum -> {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -643,7 +643,7 @@ public final class PylonItems {
                                     EquipmentSlotGroup.HEAD
                             ))
                             .build())
-                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .set(DataComponentTypes.MAX_DAMAGE, 190)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             helmet -> {
@@ -678,7 +678,7 @@ public final class PylonItems {
                                     EquipmentSlotGroup.CHEST
                             ))
                             .build())
-                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .set(DataComponentTypes.MAX_DAMAGE, 276)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             chestplate -> {
@@ -713,7 +713,7 @@ public final class PylonItems {
                                     EquipmentSlotGroup.LEGS
                             ))
                             .build())
-                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .set(DataComponentTypes.MAX_DAMAGE, 259)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             leggings -> {
@@ -748,7 +748,7 @@ public final class PylonItems {
                                     EquipmentSlotGroup.FEET
                             ))
                             .build())
-                    .set(DataComponentTypes.MAX_DAMAGE, 300)
+                    .set(DataComponentTypes.MAX_DAMAGE, 225)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             boots -> {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -204,15 +204,15 @@ public final class PylonItems {
     );
 
     public static final PylonItemSchema FERRODURALUM_ORE = new SimpleItemSchema<>(
-            pylonKey("ferroduralum_ore"),
+            pylonKey("raw_ferroduralum"),
             new ItemStackBuilder(Material.GOLD_ORE)
-                    .name("Ferroduralum ore")
+                    .name("Raw Ferroduralum")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             ferroduralum -> {
-                ShapedRecipe recipe = new ShapedRecipe(pylonKey("ferroduralum_ore"), ferroduralum);
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("raw_ferroduralum"), ferroduralum);
                 recipe.shape(
                         "CIR",
                         "   ",

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -249,7 +249,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
                                     pylonKey("ferroduralum_sword_damage"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -277,7 +277,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_axe_speed"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -305,7 +305,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_pickaxe_speed"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -333,7 +333,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_shovel_speed"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -361,7 +361,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_hoe_speed"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -389,7 +389,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_armor"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -416,7 +416,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_armor"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -443,7 +443,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_armor"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -470,7 +470,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_armor"),
-                                    1.05,
+                                    0.15,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -209,6 +209,7 @@ public final class PylonItems {
                     .name("Ferroduralum ore")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
+                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             ferroduralum -> {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -209,7 +209,6 @@ public final class PylonItems {
                     .name("Ferroduralum ore")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
-                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             ferroduralum -> {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -18,10 +18,7 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.Tag;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
-import org.bukkit.inventory.FurnaceRecipe;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.RecipeChoice;
-import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.*;
 import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
@@ -205,10 +202,12 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_ORE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_ore"),
-            new ItemStackBuilder(Material.IRON_ORE)
+            new ItemStackBuilder(Material.GOLD_ORE)
                     .name("Ferroduralum ore")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
+                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                    .set(DataComponentTypes.RARITY, ItemRarity.EPIC)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             ferroduralum -> {
@@ -219,7 +218,7 @@ public final class PylonItems {
                         "   "
                 );
                 recipe.setIngredient('C', Material.COPPER_ORE);
-                recipe.setIngredient('I', Material.IRON_ORE);
+                recipe.setIngredient('I', Material.GOLD_ORE);
                 recipe.setIngredient('R', Material.REDSTONE);
                 recipe.setCategory(CraftingBookCategory.MISC);
                 return recipe;
@@ -228,7 +227,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_INGOT = new SimpleItemSchema<>(
             pylonKey("ferroduralum_ingot"),
-            new ItemStackBuilder(Material.IRON_INGOT)
+            new ItemStackBuilder(Material.GOLD_INGOT)
                     .name("Ferroduralum ingot")
                     .lore("A crafting material to make",
                             "armor, weapons and tools.")
@@ -243,7 +242,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SWORD = new SimpleItemSchema<>(
             pylonKey("ferroduralum_sword"),
-            new ItemStackBuilder(Material.IRON_SWORD)
+            new ItemStackBuilder(Material.GOLDEN_SWORD)
                     .name("Ferroduralum sword")
                     .lore("A more powerful iron sword.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -271,7 +270,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_AXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_axe"),
-            new ItemStackBuilder(Material.IRON_AXE)
+            new ItemStackBuilder(Material.GOLDEN_AXE)
                     .name("Ferroduralum axe")
                     .lore("A more powerful iron axe")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -299,7 +298,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_PICKAXE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_pickaxe"),
-            new ItemStackBuilder(Material.IRON_PICKAXE)
+            new ItemStackBuilder(Material.GOLDEN_PICKAXE)
                     .name("Ferroduralum pickaxe")
                     .lore("A more powerful iron pickaxe")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -327,7 +326,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_SHOVEL = new SimpleItemSchema<>(
             pylonKey("ferroduralum_shovel"),
-            new ItemStackBuilder(Material.IRON_SHOVEL)
+            new ItemStackBuilder(Material.GOLDEN_SHOVEL)
                     .name("Ferroduralum shovel")
                     .lore("A more powerful iron shovel.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -355,7 +354,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HOE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_hoe"),
-            new ItemStackBuilder(Material.IRON_HOE)
+            new ItemStackBuilder(Material.GOLDEN_HOE)
                     .name("Ferroduralum hoe")
                     .lore("A more powerful iron hoe.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -383,7 +382,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_HELMET = new SimpleItemSchema<>(
             pylonKey("ferroduralum_helmet"),
-            new ItemStackBuilder(Material.IRON_HELMET)
+            new ItemStackBuilder(Material.GOLDEN_HELMET)
                     .name("Ferroduralum helmet")
                     .lore("A more powerful iron helmet.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -410,7 +409,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_CHESTPLATE = new SimpleItemSchema<>(
             pylonKey("ferroduralum_chestplate"),
-            new ItemStackBuilder(Material.IRON_CHESTPLATE)
+            new ItemStackBuilder(Material.GOLDEN_CHESTPLATE)
                     .name("Ferroduralum chestplate")
                     .lore("A more powerful iron chestplate.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -437,7 +436,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_LEGGINGS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_leggings"),
-            new ItemStackBuilder(Material.IRON_LEGGINGS)
+            new ItemStackBuilder(Material.GOLDEN_LEGGINGS)
                     .name("Ferroduralum leggings")
                     .lore("More powerful iron leggings.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
@@ -464,7 +463,7 @@ public final class PylonItems {
 
     public static final PylonItemSchema FERRODURALUM_BOOTS = new SimpleItemSchema<>(
             pylonKey("ferroduralum_boots"),
-            new ItemStackBuilder(Material.IRON_BOOTS)
+            new ItemStackBuilder(Material.GOLDEN_BOOTS)
                     .name("Ferroduralum boots")
                     .lore("More powerful iron boots.")
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -249,7 +249,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ATTACK_DAMAGE, new AttributeModifier(
                                     pylonKey("ferroduralum_sword_damage"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -277,7 +277,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_axe_speed"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -305,7 +305,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_pickaxe_speed"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -333,7 +333,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_shovel_speed"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -361,7 +361,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.BLOCK_BREAK_SPEED, new AttributeModifier(
                                     pylonKey("ferroduralum_hoe_speed"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -389,7 +389,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_helmet_armor"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -416,7 +416,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_chestplate_armor"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -443,7 +443,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_leggings_armor"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())
@@ -470,7 +470,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.ATTRIBUTE_MODIFIERS, ItemAttributeModifiers.itemAttributes()
                             .addModifier(Attribute.ARMOR, new AttributeModifier(
                                     pylonKey("ferroduralum_boots_armor"),
-                                    1.15,
+                                    1.05,
                                     AttributeModifier.Operation.MULTIPLY_SCALAR_1
                             ))
                             .build())


### PR DESCRIPTION
Serves as an item tier b/w iron and diamond, generally diamond is 25% better than iron and ferroduralum is 15% better than iron.
1 ferroduralum ore = 1 copper ore + 1 iron ore + 1 redstone dust, then smelt into ingots and all the recipes follow the vanilla style. Will keep this as a draft for a day or two, want some gameplay feedback on it before it goes through code review