### PR TITLE
Add portable echest

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
 public final class PylonItems {
-    
+
     private PylonItems() {
         throw new AssertionError("Utility class");
     }
@@ -46,6 +46,7 @@ public final class PylonItems {
                     0.25f
             )
     );
+
     public static final PylonItemSchema GOLD_SHEET = new SimpleItemSchema<>(
             pylonKey("gold_sheet"),
             new ItemStackBuilder(Material.PAPER).name("Gold Sheet").build(),
@@ -58,6 +59,7 @@ public final class PylonItems {
                     0.25f
             )
     );
+
     public static final PylonItemSchema IRON_SHEET = new SimpleItemSchema<>(
             pylonKey("iron_sheet"),
             new ItemStackBuilder(Material.PAPER).name("Iron Sheet").build(),
@@ -70,6 +72,7 @@ public final class PylonItems {
                     0.25f
             )
     );
+
     //<editor-fold desc="Hammers" defaultstate=collapsed>
     public static final Hammer.Schema STONE_HAMMER = new Hammer.Schema(
             pylonKey("stone_hammer"),
@@ -103,6 +106,7 @@ public final class PylonItems {
             Material.STONE,
             new RecipeChoice.MaterialChoice(Tag.ITEMS_STONE_TOOL_MATERIALS)
     );
+
     public static final Hammer.Schema IRON_HAMMER = new Hammer.Schema(
             pylonKey("iron_hammer"),
             Hammer.class,
@@ -135,6 +139,7 @@ public final class PylonItems {
             Material.IRON_BLOCK,
             new RecipeChoice.MaterialChoice(Material.IRON_INGOT)
     );
+
     public static final Hammer.Schema DIAMOND_HAMMER = new Hammer.Schema(
             pylonKey("diamond_hammer"),
             Hammer.class,
@@ -167,6 +172,7 @@ public final class PylonItems {
             Material.DIAMOND_BLOCK,
             new RecipeChoice.MaterialChoice(Material.DIAMOND)
     );
+
     public static final PylonItemSchema WATERING_CAN = new PylonItemSchema(
             pylonKey("watering_can"),
             WateringCan.class,
@@ -194,6 +200,7 @@ public final class PylonItems {
                     .set(DataComponentTypes.CONSUMABLE, Consumable.consumable().build())
                     .build()
     );
+
     public static final PylonItemSchema COMPRESSED_OBSIDIAN = new SimpleItemSchema<>(
             pylonKey("compressed_obsidian"),
             new ItemStackBuilder(Material.OBSIDIAN)

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -186,6 +186,7 @@ public final class PylonItems {
                     )
                     .build()
     );
+    
     public static final MonsterJerky MONSTER_JERKY = new MonsterJerky(
             pylonKey("monster_jerky"),
             SimplePylonItem.class,

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -2,11 +2,13 @@ package io.github.pylonmc.pylon.base;
 
 import io.github.pylonmc.pylon.base.items.Hammer;
 import io.github.pylonmc.pylon.base.items.MonsterJerky;
+import io.github.pylonmc.pylon.base.items.PortableEnderChest;
 import io.github.pylonmc.pylon.base.items.WateringCan;
 import io.github.pylonmc.pylon.core.item.ItemStackBuilder;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
 import io.github.pylonmc.pylon.core.item.SimpleItemSchema;
 import io.github.pylonmc.pylon.core.item.SimplePylonItem;
+import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
 import io.github.pylonmc.pylon.core.util.MiningLevel;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.Consumable;
@@ -19,6 +21,8 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -197,6 +201,37 @@ public final class PylonItems {
                     .set(DataComponentTypes.CONSUMABLE, Consumable.consumable().build())
                     .build()
     );
+
+    public static final PylonItemSchema COMPRESSED_OBSIDIAN = new SimpleItemSchema<>(
+            pylonKey("compressed_obsidian"),
+            new ItemStackBuilder(Material.OBSIDIAN)
+                    .name("Compressed Obsidian")
+                    .lore("A crafting material.")
+                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            enchantedobi -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("compressed_obsidian"), enchantedobi);
+                recipe.shape(
+                        "OOO",
+                        "OOO",
+                        "OOO"
+                );
+                recipe.setIngredient('O', Material.OBSIDIAN);
+                recipe.setCategory(CraftingBookCategory.MISC);
+                return recipe;
+            }
+    );
+
+    public static final PortableEnderChest PORTABLE_ENDER_CHEST = new PortableEnderChest(
+            pylonKey("portable_ender_chest"),
+            PortableEnderChest.Item.class,
+            new ItemStackBuilder(Material.ENDER_CHEST)
+                    .name("Portable Enderchest")
+                    .lore("<yellow>Right-Click</yellow> to open",
+                            "your enderchest.")
+                    .build()
+    );
     //</editor-fold>
 
     static void register() {
@@ -208,6 +243,7 @@ public final class PylonItems {
         DIAMOND_HAMMER.register();
         MONSTER_JERKY.register();
         WATERING_CAN.register();
+        PORTABLE_ENDER_CHEST.register();
     }
 
     private static @NotNull NamespacedKey pylonKey(@NotNull String key) {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -186,7 +186,7 @@ public final class PylonItems {
                     )
                     .build()
     );
-    
+
     public static final MonsterJerky MONSTER_JERKY = new MonsterJerky(
             pylonKey("monster_jerky"),
             SimplePylonItem.class,

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -228,6 +228,7 @@ public final class PylonItems {
             new ItemStackBuilder(Material.AMETHYST_SHARD)
                     .name("Portability Catalyst")
                     .lore("Crafting material.")
+                    .set(DataComponentTypes.ENCHANTMENT_GLINT_OVERRIDE, true)
                     .build(),
             RecipeTypes.VANILLA_CRAFTING,
             catalyst -> {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -29,6 +29,10 @@ import java.util.List;
 
 @SuppressWarnings("UnstableApiUsage")
 public final class PylonItems {
+    
+    private PylonItems() {
+        throw new AssertionError("Utility class");
+    }
 
     public static final PylonItemSchema COPPER_SHEET = new SimpleItemSchema<>(
             pylonKey("copper_sheet"),
@@ -241,10 +245,6 @@ public final class PylonItems {
                             "your enderchest.")
                     .build()
     );
-
-    private PylonItems() {
-        throw new AssertionError("Utility class");
-    }
     //</editor-fold>
 
     static void register() {

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -222,11 +222,11 @@ public final class PylonItems {
                 ShapedRecipe recipe = new ShapedRecipe(pylonKey("portability_catalyst"), catalyst);
                 recipe.shape(
                         "RRR",
-                        "RCR",
+                        "RPR",
                         "RRR"
                 );
                 recipe.setIngredient('R', Material.REDSTONE_BLOCK);
-                recipe.setIngredient('C', Material.COPPER_BLOCK);
+                recipe.setIngredient('P', Material.ENDER_PEARL);
                 recipe.setCategory(CraftingBookCategory.MISC);
                 return recipe;
             }

--- a/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/PylonItems.java
@@ -30,10 +30,6 @@ import java.util.List;
 @SuppressWarnings("UnstableApiUsage")
 public final class PylonItems {
 
-    private PylonItems() {
-        throw new AssertionError("Utility class");
-    }
-
     public static final PylonItemSchema COPPER_SHEET = new SimpleItemSchema<>(
             pylonKey("copper_sheet"),
             new ItemStackBuilder(Material.PAPER).name("Copper Sheet").build(),
@@ -46,7 +42,6 @@ public final class PylonItems {
                     0.25f
             )
     );
-
     public static final PylonItemSchema GOLD_SHEET = new SimpleItemSchema<>(
             pylonKey("gold_sheet"),
             new ItemStackBuilder(Material.PAPER).name("Gold Sheet").build(),
@@ -59,7 +54,6 @@ public final class PylonItems {
                     0.25f
             )
     );
-
     public static final PylonItemSchema IRON_SHEET = new SimpleItemSchema<>(
             pylonKey("iron_sheet"),
             new ItemStackBuilder(Material.PAPER).name("Iron Sheet").build(),
@@ -72,7 +66,6 @@ public final class PylonItems {
                     0.25f
             )
     );
-
     //<editor-fold desc="Hammers" defaultstate=collapsed>
     public static final Hammer.Schema STONE_HAMMER = new Hammer.Schema(
             pylonKey("stone_hammer"),
@@ -106,7 +99,6 @@ public final class PylonItems {
             Material.STONE,
             new RecipeChoice.MaterialChoice(Tag.ITEMS_STONE_TOOL_MATERIALS)
     );
-
     public static final Hammer.Schema IRON_HAMMER = new Hammer.Schema(
             pylonKey("iron_hammer"),
             Hammer.class,
@@ -139,7 +131,6 @@ public final class PylonItems {
             Material.IRON_BLOCK,
             new RecipeChoice.MaterialChoice(Material.IRON_INGOT)
     );
-
     public static final Hammer.Schema DIAMOND_HAMMER = new Hammer.Schema(
             pylonKey("diamond_hammer"),
             Hammer.class,
@@ -172,7 +163,6 @@ public final class PylonItems {
             Material.DIAMOND_BLOCK,
             new RecipeChoice.MaterialChoice(Material.DIAMOND)
     );
-
     public static final PylonItemSchema WATERING_CAN = new PylonItemSchema(
             pylonKey("watering_can"),
             WateringCan.class,
@@ -186,7 +176,6 @@ public final class PylonItems {
                     )
                     .build()
     );
-
     public static final MonsterJerky MONSTER_JERKY = new MonsterJerky(
             pylonKey("monster_jerky"),
             SimplePylonItem.class,
@@ -201,7 +190,6 @@ public final class PylonItems {
                     .set(DataComponentTypes.CONSUMABLE, Consumable.consumable().build())
                     .build()
     );
-
     public static final PylonItemSchema COMPRESSED_OBSIDIAN = new SimpleItemSchema<>(
             pylonKey("compressed_obsidian"),
             new ItemStackBuilder(Material.OBSIDIAN)
@@ -223,6 +211,27 @@ public final class PylonItems {
             }
     );
 
+    public static final PylonItemSchema PORTABILITY_CATALYST = new SimpleItemSchema<>(
+            pylonKey("portability_catalyst"),
+            new ItemStackBuilder(Material.AMETHYST_SHARD)
+                    .name("Portability Catalyst")
+                    .lore("Crafting material.")
+                    .build(),
+            RecipeTypes.VANILLA_CRAFTING,
+            catalyst -> {
+                ShapedRecipe recipe = new ShapedRecipe(pylonKey("portability_catalyst"), catalyst);
+                recipe.shape(
+                        "RRR",
+                        "RCR",
+                        "RRR"
+                );
+                recipe.setIngredient('R', Material.REDSTONE_BLOCK);
+                recipe.setIngredient('C', Material.COPPER_BLOCK);
+                recipe.setCategory(CraftingBookCategory.MISC);
+                return recipe;
+            }
+    );
+
     public static final PortableEnderChest PORTABLE_ENDER_CHEST = new PortableEnderChest(
             pylonKey("portable_ender_chest"),
             PortableEnderChest.Item.class,
@@ -232,6 +241,10 @@ public final class PylonItems {
                             "your enderchest.")
                     .build()
     );
+
+    private PylonItems() {
+        throw new AssertionError("Utility class");
+    }
     //</editor-fold>
 
     static void register() {

--- a/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
@@ -6,25 +6,13 @@ import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
 import io.github.pylonmc.pylon.core.item.base.Interactor;
 import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
-import net.kyori.adventure.text.Component;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.inventory.InventoryCloseEvent;
-import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.MenuType;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class PortableEnderChest extends PylonItemSchema {
     public PortableEnderChest(NamespacedKey id, Class<? extends PylonItem<? extends PortableEnderChest>> itemClass, ItemStack template){

--- a/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
@@ -1,0 +1,52 @@
+package io.github.pylonmc.pylon.base.items;
+
+import io.github.pylonmc.pylon.base.PylonBase;
+import io.github.pylonmc.pylon.base.PylonItems;
+import io.github.pylonmc.pylon.core.item.PylonItem;
+import io.github.pylonmc.pylon.core.item.PylonItemSchema;
+import io.github.pylonmc.pylon.core.item.base.Interactor;
+import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.MenuType;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class PortableEnderChest extends PylonItemSchema {
+    public PortableEnderChest(NamespacedKey id, Class<? extends PylonItem<? extends PortableEnderChest>> itemClass, ItemStack template){
+        super(id, itemClass, template);
+        ShapedRecipe recipe = new ShapedRecipe(id, template);
+        recipe.shape(
+                "OOO",
+                "OEO",
+                "OOO"
+        );
+        recipe.setIngredient('O', PylonItems.COMPRESSED_OBSIDIAN.getItemStack());
+        recipe.setIngredient('E', Material.ENDER_EYE);
+        recipe.setCategory(CraftingBookCategory.EQUIPMENT);
+        RecipeTypes.VANILLA_CRAFTING.addRecipe(recipe);
+    }
+
+    public static class Item extends PylonItem<PortableEnderChest> implements Interactor {
+        public Item(PortableEnderChest schema, ItemStack itemStack) { super(schema, itemStack); }
+
+        @Override
+        public void onUsedToRightClick(@NotNull PlayerInteractEvent event) {
+            event.getPlayer().openInventory(event.getPlayer().getEnderChest());
+        }
+    }
+}

--- a/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/items/PortableEnderChest.java
@@ -1,12 +1,10 @@
 package io.github.pylonmc.pylon.base.items;
 
-import io.github.pylonmc.pylon.base.PylonBase;
 import io.github.pylonmc.pylon.base.PylonItems;
 import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.item.PylonItemSchema;
 import io.github.pylonmc.pylon.core.item.base.Interactor;
 import io.github.pylonmc.pylon.core.recipe.RecipeTypes;
-import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
@@ -24,7 +22,7 @@ public class PortableEnderChest extends PylonItemSchema {
                 "OOO"
         );
         recipe.setIngredient('O', PylonItems.COMPRESSED_OBSIDIAN.getItemStack());
-        recipe.setIngredient('E', Material.ENDER_EYE);
+        recipe.setIngredient('E', PylonItems.PORTABILITY_CATALYST.getItemStack());
         recipe.setCategory(CraftingBookCategory.EQUIPMENT);
         RecipeTypes.VANILLA_CRAFTING.addRecipe(recipe);
     }


### PR DESCRIPTION
Does what the title says. 
Recipe is 8x compressed obsidian and one eye of ender, where each obsidian is 9x obsidian so 8*9 = 72 obsidian in total.
shape is same as vanilla, except for compressed obsidian on outside instead of regular obsidian. I think that this might be a bit too expensive though because you can already carry echests around and this only saves the convenience of having to use silk touch and place it down and pick it back up every time. 
