### PR TITLE
Fix typo in hydraulic press piston

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/items/hydraulic/machines/HydraulicPressPiston.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/items/hydraulic/machines/HydraulicPressPiston.java
@@ -104,7 +104,7 @@ public class HydraulicPressPiston extends SimpleHydraulicMachine implements Pylo
 
     @Override
     public boolean isPartOfMultiblock(@NotNull Block otherBlock) {
-        return otherBlock.getLocation().equals(getBlock().getLocation());
+        return otherBlock.getLocation().equals(getBlock().getRelative(BlockFace.DOWN, 2).getLocation());
     }
 
     @Override


### PR DESCRIPTION
turns out the issue I opened was incorrect; it was just a dumb typo (see diff, it should be very obvious why this didn't work lol)

closes https://github.com/pylonmc/pylon-core/issues/155