### PR TITLE
[ref:add-get-or-throw-to-entity-holder] Create generic SimpleItemDisplay and SimpleTextDisplay entities

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/BaseEntities.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/BaseEntities.java
@@ -1,20 +1,10 @@
 package io.github.pylonmc.pylon.base;
 
-import io.github.pylonmc.pylon.base.content.machines.fluid.FluidFilter;
-import io.github.pylonmc.pylon.base.content.machines.fluid.FluidMeter;
-import io.github.pylonmc.pylon.base.content.machines.fluid.FluidValve;
-import io.github.pylonmc.pylon.base.content.machines.fluid.FluidVoider;
-import io.github.pylonmc.pylon.base.content.machines.fluid.PortableFluidTank;
+import io.github.pylonmc.pylon.base.entities.SimpleItemDisplay;
+import io.github.pylonmc.pylon.base.entities.SimpleTextDisplay;
 import io.github.pylonmc.pylon.base.fluid.pipe.FluidPipeDisplay;
 import io.github.pylonmc.pylon.base.fluid.pipe.connection.FluidConnectionDisplay;
 import io.github.pylonmc.pylon.base.fluid.pipe.connection.FluidConnectionInteraction;
-import io.github.pylonmc.pylon.base.content.machines.hydraulics.HydraulicHammerHead;
-import io.github.pylonmc.pylon.base.content.machines.hydraulics.HydraulicMixingAttachment;
-import io.github.pylonmc.pylon.base.content.machines.simple.Press;
-import io.github.pylonmc.pylon.base.content.machines.hydraulics.HydraulicPressPiston;
-import io.github.pylonmc.pylon.base.content.machines.simple.Grindstone;
-import io.github.pylonmc.pylon.base.content.building.Pedestal;
-import io.github.pylonmc.pylon.base.content.machines.smelting.SmelteryController;
 import io.github.pylonmc.pylon.core.entity.PylonEntity;
 import org.bukkit.entity.Interaction;
 import org.bukkit.entity.ItemDisplay;
@@ -27,23 +17,11 @@ public final class BaseEntities {
     }
 
     public static void initialize() {
-        PylonEntity.register(Grindstone.GrindstoneItemEntity.KEY, ItemDisplay.class, Grindstone.GrindstoneItemEntity.class);
-        PylonEntity.register(Grindstone.GrindstoneBlockEntity.KEY, ItemDisplay.class, Grindstone.GrindstoneBlockEntity.class);
-        PylonEntity.register(FluidConnectionDisplay.KEY, ItemDisplay.class, FluidConnectionDisplay.class);
-        PylonEntity.register(FluidConnectionInteraction.KEY, Interaction.class, FluidConnectionInteraction.class);
-        PylonEntity.register(Pedestal.PedestalItemEntity.KEY, ItemDisplay.class, Pedestal.PedestalItemEntity.class);
-        PylonEntity.register(FluidFilter.FluidDisplay.KEY, ItemDisplay.class, FluidFilter.FluidDisplay.class);
-        PylonEntity.register(FluidFilter.MainDisplay.KEY, ItemDisplay.class, FluidFilter.MainDisplay.class);
-        PylonEntity.register(FluidPipeDisplay.KEY, ItemDisplay.class, FluidPipeDisplay.class);
-        PylonEntity.register(PortableFluidTank.FluidTankEntity.KEY, ItemDisplay.class, PortableFluidTank.FluidTankEntity.class);
-        PylonEntity.register(FluidValve.FluidValveDisplay.KEY, ItemDisplay.class, FluidValve.FluidValveDisplay.class);
-        PylonEntity.register(FluidMeter.FlowRateDisplay.KEY, TextDisplay.class, FluidMeter.FlowRateDisplay.class);
-        PylonEntity.register(FluidVoider.MainDisplay.KEY, ItemDisplay.class, FluidVoider.MainDisplay.class);
-        PylonEntity.register(SmelteryController.FluidPixelEntity.KEY, TextDisplay.class, SmelteryController.FluidPixelEntity.class);
-        PylonEntity.register(Press.PressCoverEntity.KEY, ItemDisplay.class, Press.PressCoverEntity.class);
-        PylonEntity.register(HydraulicMixingAttachment.ShaftEntity.KEY, ItemDisplay.class, HydraulicMixingAttachment.ShaftEntity.class);
-        PylonEntity.register(HydraulicPressPiston.PistonShaftEntity.KEY, ItemDisplay.class, HydraulicPressPiston.PistonShaftEntity.class);
-        PylonEntity.register(HydraulicHammerHead.HammerHeadEntity.KEY, ItemDisplay.class, HydraulicHammerHead.HammerHeadEntity.class);
-        PylonEntity.register(HydraulicHammerHead.HammerTipEntity.KEY, ItemDisplay.class, HydraulicHammerHead.HammerTipEntity.class);
+        PylonEntity.register(BaseKeys.SIMPLE_ITEM_DISPLAY, ItemDisplay.class, SimpleItemDisplay.class);
+        PylonEntity.register(BaseKeys.SIMPLE_TEXT_DISPLAY, TextDisplay.class, SimpleTextDisplay.class);
+
+        PylonEntity.register(BaseKeys.FLUID_CONNECTION_DISPLAY, ItemDisplay.class, FluidConnectionDisplay.class);
+        PylonEntity.register(BaseKeys.FLUID_CONNECTION_INTERACTION, Interaction.class, FluidConnectionInteraction.class);
+        PylonEntity.register(BaseKeys.FLUID_PIPE_DISPLAY, ItemDisplay.class, FluidPipeDisplay.class);
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/BaseKeys.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/BaseKeys.java
@@ -196,6 +196,15 @@ public class BaseKeys {
     public static final NamespacedKey SOLAR_PURIFICATION_TOWER_5 = baseKey("solar_purification_tower_5");
     public static final NamespacedKey COAL_FIRED_PURIFICATION_TOWER = baseKey("coal_fired_purification_tower");
 
-    public static final NamespacedKey FLUID_PIPE_MARKER =  baseKey("fluid_pipe_marker");
-    public static final NamespacedKey FLUID_PIPE_CONNECTOR =  baseKey("fluid_pipe_connector");
+    public static final NamespacedKey FLUID_PIPE_MARKER = baseKey("fluid_pipe_marker");
+    public static final NamespacedKey FLUID_PIPE_CONNECTOR = baseKey("fluid_pipe_connector");
+
+    public static final NamespacedKey SIMPLE_ITEM_DISPLAY = baseKey("simple_item_display");
+    public static final NamespacedKey SIMPLE_TEXT_DISPLAY = baseKey("simple_text_display");
+
+    public static final NamespacedKey FLUID_CONNECTION_DISPLAY = baseKey("fluid_connection_display");
+    public static final NamespacedKey FLUID_CONNECTION_INTERACTION = baseKey("fluid_connection_interaction");
+
+    public static final NamespacedKey FLUID_PIPE_DISPLAY = baseKey("fluid_pipe_display");
+
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/building/Pedestal.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/building/Pedestal.java
@@ -1,5 +1,6 @@
 package io.github.pylonmc.pylon.base.content.building;
 
+import io.github.pylonmc.pylon.base.entities.SimpleItemDisplay;
 import io.github.pylonmc.pylon.core.block.PylonBlock;
 import io.github.pylonmc.pylon.core.block.base.PylonEntityHolderBlock;
 import io.github.pylonmc.pylon.core.block.base.PylonInteractableBlock;
@@ -52,17 +53,10 @@ public class Pedestal extends PylonBlock implements PylonEntityHolderBlock, Pylo
     
     @Override
     public @NotNull Map<String, PylonEntity<?>> createEntities(@NotNull BlockCreateContext context) {
-        ItemDisplay display = new ItemDisplayBuilder()
+        return Map.of("item", new SimpleItemDisplay(new ItemDisplayBuilder()
                 .transformation(transformBuilder().buildForItemDisplay())
-                .build(getBlock().getLocation().toCenterLocation());
-        return Map.of("item", new PedestalItemEntity(display));
-    }
-
-    public TransformBuilder transformBuilder() {
-        return new TransformBuilder()
-                .translate(0, 0.7, 0)
-                .scale(0.4)
-                .rotate(0, rotation, 0);
+                .build(getBlock().getLocation().toCenterLocation())
+        ));
     }
 
     @Override
@@ -79,7 +73,7 @@ public class Pedestal extends PylonBlock implements PylonEntityHolderBlock, Pylo
 
         event.setCancelled(true);
 
-        ItemDisplay display = getHeldEntity(PedestalItemEntity.class, "item").getEntity();
+        ItemDisplay display = getItemDisplay();
 
         // rotate
         if (event.getPlayer().isSneaking()) {
@@ -113,15 +107,13 @@ public class Pedestal extends PylonBlock implements PylonEntityHolderBlock, Pylo
     }
 
     public ItemDisplay getItemDisplay() {
-        return getHeldEntity(PedestalItemEntity.class, "item").getEntity();
+        return getHeldEntityOrThrow(SimpleItemDisplay.class, "item").getEntity();
     }
 
-    public static class PedestalItemEntity extends PylonEntity<ItemDisplay> {
-
-        public static final NamespacedKey KEY = baseKey("pedestal_item");
-
-        public PedestalItemEntity(@NotNull ItemDisplay entity) {
-            super(KEY, entity);
-        }
+    public TransformBuilder transformBuilder() {
+        return new TransformBuilder()
+                .translate(0, 0.7, 0)
+                .scale(0.4)
+                .rotate(0, rotation, 0);
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/FluidFilter.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/FluidFilter.java
@@ -1,6 +1,7 @@
 package io.github.pylonmc.pylon.base.content.machines.fluid;
 
 import com.google.common.base.Preconditions;
+import io.github.pylonmc.pylon.base.entities.SimpleItemDisplay;
 import io.github.pylonmc.pylon.base.fluid.PylonFluidIoBlock;
 import io.github.pylonmc.pylon.base.fluid.pipe.SimpleFluidConnectionPoint;
 import io.github.pylonmc.pylon.base.fluid.pipe.connection.FluidConnectionInteraction;
@@ -37,7 +38,6 @@ import xyz.xenondevs.invui.window.Window;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
 
@@ -91,8 +91,21 @@ public class FluidFilter extends PylonBlock implements PylonFluidIoBlock, PylonI
         Player player = ((BlockCreateContext.PlayerPlace) context).getPlayer();
         Block block = context.getBlock();
 
-        entities.put("main", new MainDisplay(block, player));
-        entities.put("fluid", new FluidDisplay(block, player));
+        entities.put("main", new SimpleItemDisplay(new ItemDisplayBuilder()
+                .material(MAIN_MATERIAL)
+                .transformation(new TransformBuilder()
+                        .lookAlong(PylonUtils.rotateToPlayerFacing(player, BlockFace.EAST, false).getDirection().toVector3d())
+                        .scale(0.25, 0.25, 0.5)
+                )
+                .build(block.getLocation().toCenterLocation())));
+
+        entities.put("fluid", new SimpleItemDisplay(new ItemDisplayBuilder()
+                .material(NO_FLUID_MATERIAL)
+                .transformation(new TransformBuilder()
+                        .lookAlong(PylonUtils.rotateToPlayerFacing(player, BlockFace.EAST, false).getDirection().toVector3d())
+                        .scale(0.2, 0.3, 0.45)
+                )
+                .build(block.getLocation().toCenterLocation())));
 
         return entities;
     }
@@ -118,8 +131,8 @@ public class FluidFilter extends PylonBlock implements PylonFluidIoBlock, PylonI
         ));
     }
 
-    private @NotNull FluidDisplay getFluidDisplay() {
-        return Objects.requireNonNull(getHeldEntity(FluidDisplay.class, "fluid"));
+    private @NotNull ItemDisplay getFluidDisplay() {
+        return getHeldEntityOrThrow(SimpleItemDisplay.class, "fluid").getEntity();
     }
 
     @Override
@@ -149,65 +162,16 @@ public class FluidFilter extends PylonBlock implements PylonFluidIoBlock, PylonI
     }
 
     private @NotNull FluidConnectionPoint getOutputPoint() {
-        //noinspection DataFlowIssue
-        return getHeldEntity(FluidConnectionInteraction.class, "output").getPoint();
+        return getHeldEntityOrThrow(FluidConnectionInteraction.class, "output").getPoint();
     }
 
     private @NotNull FluidConnectionPoint getInputPoint() {
-        //noinspection DataFlowIssue
-        return getHeldEntity(FluidConnectionInteraction.class, "input").getPoint();
+        return getHeldEntityOrThrow(FluidConnectionInteraction.class, "input").getPoint();
     }
 
     public void setFluid(PylonFluid fluid) {
         this.fluid = fluid;
         this.buffer = 0;
-        getFluidDisplay().setFluid(fluid);
-    }
-
-    public static class MainDisplay extends PylonEntity<ItemDisplay> {
-
-        public static final NamespacedKey KEY = baseKey("fluid_filter_main_display");
-
-        @SuppressWarnings("unused")
-        public MainDisplay(@NotNull ItemDisplay entity) {
-            super(entity);
-        }
-
-        public MainDisplay(@NotNull Block block, @NotNull Player player) {
-            super(KEY, new ItemDisplayBuilder()
-                    .material(MAIN_MATERIAL)
-                    .transformation(new TransformBuilder()
-                            .lookAlong(PylonUtils.rotateToPlayerFacing(player, BlockFace.EAST, false).getDirection().toVector3d())
-                            .scale(0.25, 0.25, 0.5)
-                    )
-                    .build(block.getLocation().toCenterLocation())
-            );
-        }
-
-    }
-
-    public static class FluidDisplay extends PylonEntity<ItemDisplay> {
-
-        public static final NamespacedKey KEY = baseKey("fluid_filter_fluid_display");
-
-        @SuppressWarnings("unused")
-        public FluidDisplay(@NotNull ItemDisplay entity) {
-            super(entity);
-        }
-
-        public FluidDisplay(@NotNull Block block, @NotNull Player player) {
-            super(KEY, new ItemDisplayBuilder()
-                    .material(NO_FLUID_MATERIAL)
-                    .transformation(new TransformBuilder()
-                            .lookAlong(PylonUtils.rotateToPlayerFacing(player, BlockFace.EAST, false).getDirection().toVector3d())
-                            .scale(0.2, 0.3, 0.45)
-                    )
-                    .build(block.getLocation().toCenterLocation())
-            );
-        }
-
-        public void setFluid(@Nullable PylonFluid fluid) {
-            getEntity().setItemStack(new ItemStack(fluid == null ? NO_FLUID_MATERIAL : fluid.getMaterial()));
-        }
+        getFluidDisplay().setItemStack(new ItemStack(fluid == null ? NO_FLUID_MATERIAL : fluid.getMaterial()));
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/FluidVoider.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/FluidVoider.java
@@ -1,5 +1,6 @@
 package io.github.pylonmc.pylon.base.content.machines.fluid;
 
+import io.github.pylonmc.pylon.base.entities.SimpleItemDisplay;
 import io.github.pylonmc.pylon.base.fluid.PylonFluidIoBlock;
 import io.github.pylonmc.pylon.base.fluid.pipe.SimpleFluidConnectionPoint;
 import io.github.pylonmc.pylon.core.block.PylonBlock;
@@ -15,10 +16,8 @@ import io.github.pylonmc.pylon.core.registry.PylonRegistry;
 import io.github.pylonmc.pylon.core.util.gui.unit.UnitFormat;
 import net.kyori.adventure.text.ComponentLike;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.ItemDisplay;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
@@ -27,8 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
 
 
 public class FluidVoider extends PylonBlock implements PylonFluidIoBlock {
@@ -73,8 +70,13 @@ public class FluidVoider extends PylonBlock implements PylonFluidIoBlock {
     @Override
     public @NotNull Map<String, PylonEntity<?>> createEntities(@NotNull BlockCreateContext context) {
         Map<String, PylonEntity<?>> entities = PylonFluidIoBlock.super.createEntities(context);
-        @NotNull Block block = getBlock();
-        entities.put("main", new MainDisplay(block, mainDisplaySize));
+        entities.put("main", new SimpleItemDisplay(new ItemDisplayBuilder()
+                .material(MAIN_MATERIAL)
+                .transformation(new TransformBuilder()
+                        .scale(mainDisplaySize)
+                )
+                .build(getBlock().getLocation().toCenterLocation())
+        ));
         return entities;
     }
 
@@ -88,25 +90,5 @@ public class FluidVoider extends PylonBlock implements PylonFluidIoBlock {
     @Override
     public void addFluid(@NotNull String connectionPoint, @NotNull PylonFluid fluid, double amount) {
         // do nothing lol
-    }
-
-    public static class MainDisplay extends PylonEntity<ItemDisplay> {
-
-        public static final NamespacedKey KEY = baseKey("fluid_voider_main_display");
-
-        @SuppressWarnings("unused")
-        public MainDisplay(@NotNull ItemDisplay entity) {
-            super(entity);
-        }
-
-        public MainDisplay(@NotNull Block block, double mainDisplaySize) {
-            super(KEY, new ItemDisplayBuilder()
-                    .material(MAIN_MATERIAL)
-                    .transformation(new TransformBuilder()
-                            .scale(mainDisplaySize)
-                    )
-                    .build(block.getLocation().toCenterLocation())
-            );
-        }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/PortableFluidTank.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/fluid/PortableFluidTank.java
@@ -2,6 +2,7 @@ package io.github.pylonmc.pylon.base.content.machines.fluid;
 
 import io.github.pylonmc.pylon.base.PylonBase;
 import io.github.pylonmc.pylon.base.BaseFluids;
+import io.github.pylonmc.pylon.base.entities.SimpleItemDisplay;
 import io.github.pylonmc.pylon.base.fluid.PylonFluidIoBlock;
 import io.github.pylonmc.pylon.base.fluid.pipe.SimpleFluidConnectionPoint;
 import io.github.pylonmc.pylon.core.block.PylonBlock;
@@ -31,7 +32,6 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
-import org.bukkit.entity.ItemDisplay;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.player.PlayerInteractEvent;
@@ -151,10 +151,9 @@ public class PortableFluidTank extends PylonBlock implements PylonFluidIoBlock, 
     @Override
     public @NotNull Map<String, PylonEntity<?>> createEntities(@NotNull BlockCreateContext context) {
         Map<String, PylonEntity<?>> entities = PylonFluidIoBlock.super.createEntities(context);
-
-        ItemDisplay fluidDisplay = new ItemDisplayBuilder().build(getBlock().getLocation().toCenterLocation());
-        entities.put("fluid", new FluidTankEntity(fluidDisplay));
-
+        entities.put("fluid", new SimpleItemDisplay(new ItemDisplayBuilder()
+                .build(getBlock().getLocation().toCenterLocation()))
+        );
         return entities;
     }
 
@@ -199,11 +198,7 @@ public class PortableFluidTank extends PylonBlock implements PylonFluidIoBlock, 
 
     public void setFluid(@Nullable PylonFluid fluid) {
         this.fluidType = fluid;
-
-        ItemDisplay display = getFluidDisplay();
-        if (display != null) {
-            display.setItemStack(fluid == null ? null : new ItemStack(fluid.getMaterial()));
-        }
+        getFluidDisplay().getEntity().setItemStack(fluid == null ? null : new ItemStack(fluid.getMaterial()));
     }
 
     public void setAmount(double amount) {
@@ -219,21 +214,15 @@ public class PortableFluidTank extends PylonBlock implements PylonFluidIoBlock, 
 
     public void updateFluidDisplayHeight() {
         float scale = (float) (0.9F * fluidAmount / capacity);
-        ItemDisplay display = getFluidDisplay();
-        if (display != null) {
-            display.setTransformationMatrix(new TransformBuilder()
+        getFluidDisplay().getEntity().setTransformationMatrix(new TransformBuilder()
                     .translate(0.0, -0.45 + scale / 2, 0.0)
                     .scale(0.9, scale, 0.9)
-                    .buildForItemDisplay());
-        }
+                    .buildForItemDisplay()
+        );
     }
 
-    private @Nullable ItemDisplay getFluidDisplay() {
-        FluidTankEntity fluidTankEntity = getHeldEntity(FluidTankEntity.class, "fluid");
-        if (fluidTankEntity == null) {
-            return null;
-        }
-        return fluidTankEntity.getEntity();
+    public @NotNull SimpleItemDisplay getFluidDisplay() {
+        return getHeldEntityOrThrow(SimpleItemDisplay.class, "fluid");
     }
 
     @Override
@@ -337,15 +326,6 @@ public class PortableFluidTank extends PylonBlock implements PylonFluidIoBlock, 
                 item.subtract();
                 event.getPlayer().give(finalNewItemStack);
             }, 0);
-        }
-    }
-
-    public static class FluidTankEntity extends PylonEntity<ItemDisplay> {
-
-        public static final NamespacedKey KEY = baseKey("fluid_tank_entity");
-
-        public FluidTankEntity(@NotNull ItemDisplay entity) {
-            super(KEY, entity);
         }
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/CoalFiredPurificationTower.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/CoalFiredPurificationTower.java
@@ -7,6 +7,7 @@ import io.github.pylonmc.pylon.core.block.base.PylonGuiBlock;
 import io.github.pylonmc.pylon.core.block.base.PylonSimpleMultiblock;
 import io.github.pylonmc.pylon.core.block.base.PylonTickingBlock;
 import io.github.pylonmc.pylon.core.block.context.BlockCreateContext;
+import io.github.pylonmc.pylon.core.config.Config;
 import io.github.pylonmc.pylon.core.config.ConfigSection;
 import io.github.pylonmc.pylon.core.config.Settings;
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers;
@@ -41,13 +42,14 @@ import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
 public class CoalFiredPurificationTower extends SimplePurificationMachine
         implements PylonSimpleMultiblock, PylonTickingBlock, PylonGuiBlock {
 
-    public static final double FLUID_MB_PER_SECOND = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER).getOrThrow("fluid-mb-per-second", Integer.class);
-    public static final double FLUID_BUFFER = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER).getOrThrow("fluid-buffer-mb", Integer.class);
-    public static final int TICK_INTERVAL = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER).getOrThrow("tick-interval", Integer.class);
+    private static final Config settings = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER);
+    public static final double FLUID_MB_PER_SECOND = settings.getOrThrow("fluid-mb-per-second", Integer.class);
+    public static final double FLUID_BUFFER = settings.getOrThrow("fluid-buffer-mb", Integer.class);
+    public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", Integer.class);
     public static final Map<ItemStack, Integer> FUELS = new HashMap<>();
 
     static {
-        ConfigSection config = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER).getSectionOrThrow("fuels");
+        ConfigSection config = settings.getSectionOrThrow("fuels");
         for (String key : config.getKeys()) {
             FUELS.put(config.getItemOrThrow(key), config.getOrThrow(key, Integer.class));
         }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicGrindstoneTurner.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicGrindstoneTurner.java
@@ -8,6 +8,7 @@ import io.github.pylonmc.pylon.core.block.BlockStorage;
 import io.github.pylonmc.pylon.core.block.base.PylonMultiblock;
 import io.github.pylonmc.pylon.core.block.base.PylonTickingBlock;
 import io.github.pylonmc.pylon.core.block.context.BlockCreateContext;
+import io.github.pylonmc.pylon.core.config.Config;
 import io.github.pylonmc.pylon.core.config.Settings;
 import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.util.gui.unit.UnitFormat;
@@ -28,12 +29,11 @@ import java.util.Set;
 public class HydraulicGrindstoneTurner extends SimpleHydraulicMachine implements PylonMultiblock, PylonTickingBlock {
     public static final Component MISSING_GRINDSTONE = Component.translatable("pylon.pylonbase.message.hydraulic_status.missing_grindstone");
 
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER).getOrThrow("hydraulic-fluid-input-mb-per-second", Integer.class);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER).getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", Integer.class);
-
-    public static final double HYDRAULIC_FLUID_BUFFER = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER).getOrThrow("hydraulic-fluid-buffer", Integer.class);
-    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER).getOrThrow("dirty-hydraulic-fluid-buffer", Integer.class);
-
+    private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER);
+    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", Integer.class);
+    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", Integer.class);
+    public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", Integer.class);
+    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("dirty-hydraulic-fluid-buffer", Integer.class);
 
     public static class Item extends PylonItem {
 

--- a/src/main/java/io/github/pylonmc/pylon/base/content/tools/Sprinkler.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/tools/Sprinkler.java
@@ -9,6 +9,7 @@ import io.github.pylonmc.pylon.core.block.BlockStorage;
 import io.github.pylonmc.pylon.core.block.PylonBlock;
 import io.github.pylonmc.pylon.core.block.base.PylonTickingBlock;
 import io.github.pylonmc.pylon.core.block.context.BlockCreateContext;
+import io.github.pylonmc.pylon.core.config.Config;
 import io.github.pylonmc.pylon.core.config.Settings;
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers;
 import io.github.pylonmc.pylon.core.event.PrePylonBlockPlaceEvent;
@@ -54,10 +55,10 @@ public class Sprinkler extends PylonBlock implements PylonFluidIoBlock, PylonTic
 
     public static final NamespacedKey WATER_BUFFER_KEY = baseKey("water_buffer");
 
-    public static final WateringSettings SETTINGS = WateringSettings.fromConfig(Settings.get(BaseKeys.SPRINKLER));
-
-    public static final int TICK_INTERVAL = Settings.get(BaseKeys.SPRINKLER).getOrThrow("tick-interval", Integer.class);
-    public static final double WATER_PER_SECOND = Settings.get(BaseKeys.SPRINKLER).getOrThrow("water-per-second", Integer.class);
+    private static final Config settings = Settings.get(BaseKeys.SPRINKLER);
+    public static final WateringSettings SETTINGS = WateringSettings.fromConfig(settings);
+    public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", Integer.class);
+    public static final double WATER_PER_SECOND = settings.getOrThrow("water-per-second", Integer.class);
 
     private double waterBuffer;
 

--- a/src/main/java/io/github/pylonmc/pylon/base/entities/SimpleItemDisplay.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/entities/SimpleItemDisplay.java
@@ -1,0 +1,22 @@
+package io.github.pylonmc.pylon.base.entities;
+
+import io.github.pylonmc.pylon.base.BaseKeys;
+import io.github.pylonmc.pylon.core.entity.PylonEntity;
+import org.bukkit.entity.ItemDisplay;
+import org.jetbrains.annotations.NotNull;
+import org.joml.Matrix4f;
+
+
+public final class SimpleItemDisplay extends PylonEntity<ItemDisplay> {
+
+    @SuppressWarnings("unused")
+    public SimpleItemDisplay(@NotNull ItemDisplay entity) {
+        super(BaseKeys.SIMPLE_ITEM_DISPLAY, entity);
+    }
+
+    public void setTransform(int durationTicks, Matrix4f matrix) {
+        getEntity().setTransformationMatrix(matrix);
+        getEntity().setInterpolationDelay(0);
+        getEntity().setInterpolationDuration(durationTicks);
+    }
+}

--- a/src/main/java/io/github/pylonmc/pylon/base/entities/SimpleTextDisplay.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/entities/SimpleTextDisplay.java
@@ -1,0 +1,16 @@
+package io.github.pylonmc.pylon.base.entities;
+
+import io.github.pylonmc.pylon.base.BaseKeys;
+import io.github.pylonmc.pylon.core.entity.PylonEntity;
+import org.bukkit.entity.ItemDisplay;
+import org.bukkit.entity.TextDisplay;
+import org.jetbrains.annotations.NotNull;
+
+
+public final class SimpleTextDisplay extends PylonEntity<TextDisplay> {
+
+    @SuppressWarnings("unused")
+    public SimpleTextDisplay(@NotNull TextDisplay entity) {
+        super(BaseKeys.SIMPLE_ITEM_DISPLAY, entity);
+    }
+}

--- a/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/FluidPipeDisplay.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/FluidPipeDisplay.java
@@ -1,6 +1,7 @@
 package io.github.pylonmc.pylon.base.fluid.pipe;
 
 import com.google.common.base.Preconditions;
+import io.github.pylonmc.pylon.base.BaseKeys;
 import io.github.pylonmc.pylon.base.fluid.pipe.connection.FluidConnectionInteraction;
 import io.github.pylonmc.pylon.base.fluid.pipe.connection.connecting.ConnectingService;
 import io.github.pylonmc.pylon.base.content.machines.fluid.FluidPipe;
@@ -29,9 +30,6 @@ import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
 
 
 public class FluidPipeDisplay extends PylonEntity<ItemDisplay> {
-
-    public static final NamespacedKey KEY = baseKey("fluid_pipe_display");
-
     private static final NamespacedKey AMOUNT_KEY = baseKey("amount");
     private static final NamespacedKey PIPE_KEY = baseKey("pipe");
     private static final NamespacedKey FROM_KEY = baseKey("from");
@@ -73,7 +71,7 @@ public class FluidPipeDisplay extends PylonEntity<ItemDisplay> {
             @NotNull FluidConnectionInteraction from,
             @NotNull FluidConnectionInteraction to
     ) {
-        super(KEY, makeDisplay(pipe, from, to));
+        super(BaseKeys.FLUID_PIPE_DISPLAY, makeDisplay(pipe, from, to));
         this.pipe = pipe;
         this.amount = amount;
         this.from = from.getUuid();

--- a/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/connection/FluidConnectionDisplay.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/connection/FluidConnectionDisplay.java
@@ -1,23 +1,19 @@
 package io.github.pylonmc.pylon.base.fluid.pipe.connection;
 
+import io.github.pylonmc.pylon.base.BaseKeys;
 import io.github.pylonmc.pylon.core.entity.EntityStorage;
 import io.github.pylonmc.pylon.core.entity.PylonEntity;
 import io.github.pylonmc.pylon.core.entity.display.ItemDisplayBuilder;
 import io.github.pylonmc.pylon.core.entity.display.transform.TransformBuilder;
 import io.github.pylonmc.pylon.core.fluid.FluidConnectionPoint;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.block.BlockFace;
 import org.bukkit.entity.ItemDisplay;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3d;
 
-import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
-
 
 public class FluidConnectionDisplay extends PylonEntity<ItemDisplay> {
-
-    public static final NamespacedKey KEY = baseKey("fluid_connection_display");
 
     @SuppressWarnings("unused")
     public FluidConnectionDisplay(@NotNull ItemDisplay entity) {
@@ -25,11 +21,11 @@ public class FluidConnectionDisplay extends PylonEntity<ItemDisplay> {
     }
 
     public FluidConnectionDisplay(@NotNull FluidConnectionPoint point, @NotNull BlockFace face, float radius) {
-        super(KEY, makeDisplay(point, face.getDirection().clone().multiply(radius).toVector3d()));
+        super(BaseKeys.FLUID_CONNECTION_DISPLAY, makeDisplay(point, face.getDirection().clone().multiply(radius).toVector3d()));
     }
 
     public FluidConnectionDisplay(@NotNull FluidConnectionPoint point) {
-        super(KEY, makeDisplay(point, new Vector3d(0, 0, 0)));
+        super(BaseKeys.FLUID_CONNECTION_DISPLAY, makeDisplay(point, new Vector3d(0, 0, 0)));
     }
 
     private static @NotNull Material materialFromType(@NotNull FluidConnectionPoint.Type type) {

--- a/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/connection/FluidConnectionInteraction.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/fluid/pipe/connection/FluidConnectionInteraction.java
@@ -1,6 +1,7 @@
 package io.github.pylonmc.pylon.base.fluid.pipe.connection;
 
 import com.google.common.base.Preconditions;
+import io.github.pylonmc.pylon.base.BaseKeys;
 import io.github.pylonmc.pylon.base.fluid.pipe.FluidPipeDisplay;
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers;
 import io.github.pylonmc.pylon.core.entity.EntityStorage;
@@ -35,8 +36,6 @@ public class FluidConnectionInteraction extends PylonEntity<Interaction> impleme
 
     public static final float POINT_SIZE = 0.12F;
 
-    public static final NamespacedKey KEY = baseKey("fluid_connection_interaction");
-
     private static final NamespacedKey CONNECTED_PIPE_DISPLAYS_KEY = baseKey("connected_pipe_displays");
     private static final NamespacedKey CONNECTION_POINT_KEY = baseKey("connection_point");
     private static final NamespacedKey DISPLAY_KEY = baseKey("display");
@@ -65,7 +64,7 @@ public class FluidConnectionInteraction extends PylonEntity<Interaction> impleme
     }
 
     private FluidConnectionInteraction(@NotNull FluidConnectionPoint point, @NotNull BlockFace face, float radius) {
-        super(KEY, makeInteraction(point, face.getDirection().clone().multiply(radius)));
+        super(BaseKeys.FLUID_CONNECTION_INTERACTION, makeInteraction(point, face.getDirection().clone().multiply(radius)));
 
         this.connectedPipeDisplays = new HashSet<>();
         this.point = point;
@@ -77,7 +76,7 @@ public class FluidConnectionInteraction extends PylonEntity<Interaction> impleme
     }
 
     private FluidConnectionInteraction(@NotNull FluidConnectionPoint point) {
-        super(KEY, makeInteraction(point, new Vector(0, 0, 0)));
+        super(BaseKeys.FLUID_CONNECTION_INTERACTION, makeInteraction(point, new Vector(0, 0, 0)));
 
         this.connectedPipeDisplays = new HashSet<>();
         this.point = point;


### PR DESCRIPTION
- Adds SimpleItemDisplay and SimpleTextDisplay
- Converts most machines to use SimpleItemDisplay and SimpleTextDisplay
- Make machines use getHeldEntityOrThrow instead of Objects.requireNonNull(getHeldEntity(...))
- Make machines with 3+ settings fields store `Settings.get(BaseKeys.[some key])` in a field to increase readability