### PR TITLE
Fix immobilizer thread safety issues

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/content/building/Immobilizer.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/building/Immobilizer.java
@@ -74,11 +74,11 @@ public class Immobilizer extends PylonBlock implements PylonPiston {
             }
             frozenPlayers.add(player);
             for (int i = 0; i < duration / particlePeriod; i++) {
-                Bukkit.getScheduler().runTaskLaterAsynchronously(PylonBase.getInstance(), new PlayerVFX(player, this), (long) i * particlePeriod);
+                Bukkit.getScheduler().runTaskLater(PylonBase.getInstance(), new PlayerVFX(player, this), (long) i * particlePeriod);
             }
             player.getPersistentDataContainer().set(cooldownKey, PersistentDataType.INTEGER, Bukkit.getCurrentTick());
         }
-        Bukkit.getScheduler().runTaskLaterAsynchronously(PylonBase.getInstance(), () -> frozenPlayers.clear(), duration);
+        Bukkit.getScheduler().runTaskLater(PylonBase.getInstance(), () -> frozenPlayers.clear(), duration);
     }
 
     public static class PlayerVFX implements Runnable {


### PR DESCRIPTION
Closes #114 
At least someone noticed my mistake
ty to that random person in gen chat :heart:
Moved both runTaskLater calls from the async to the non-async version, since there is no ConcurrentHashSet both calls must be made on the main thread to avoid unintended consequences