### PR TITLE
fix color tag on copper

### DIFF
--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -859,7 +859,7 @@ fluid:
   castable:
     display-text: "<arrow> <gray>Casts into <white>%result%"
   brass: "<gold>Brass"
-  bronze: "<brown>Bronze"
+  bronze: "<#8d6f64>Bronze"
   cobalt: "<gray>Cobalt"
   copper: "<#b5591b>Copper"
   gold: "<gold>Gold"


### PR DESCRIPTION
<brown> isn't a defined minecraft color, just used a hex color instead. Closes #126 