### PR TITLE
Fix negative temperature

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/smelting/SmelteryController.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/smelting/SmelteryController.java
@@ -439,11 +439,6 @@ public final class SmelteryController extends SmelteryComponent
         return heatLossCoeff * (t - t0) * dt;
     }
 
-    @SuppressWarnings("SameParameterValue")
-    private static double stefanBoltzmannLaw(double emissivity, double t, double t0, double dt) {
-        return emissivity * STEFAN_BOLTZMANN_CONSTANT * (Math.pow(t, 4) - Math.pow(t0, 4)) * dt;
-    }
-
     private static final Config settings = Settings.get(BaseKeys.SMELTERY_CONTROLLER);
     private static final double STEFAN_BOLTZMANN_CONSTANT = 5.67e-8; // W/m^2*K^4
     private static final double SPECIFIC_HEAT = settings.getOrThrow("specific-heat.fluid", Double.class);
@@ -474,13 +469,7 @@ public final class SmelteryController extends SmelteryComponent
                 ROOM_TEMPERATURE_KELVIN,
                 dt
         );
-        double radiativeHeatLoss = stefanBoltzmannLaw(
-                EMISSIVITY,
-                kelvin,
-                ROOM_TEMPERATURE_KELVIN,
-                dt
-        );
-        temperature -= ((conductiveHeatLoss + radiativeHeatLoss) * surfaceArea) / (getHeatCapacity() + getAirHeatCapacity());
+        temperature -= (conductiveHeatLoss * surfaceArea) / (getHeatCapacity() + getAirHeatCapacity());
     }
 
     private double heatAccumulation = 0;


### PR DESCRIPTION
Desmos simulation: https://www.desmos.com/calculator/2jsf3qwyb5

Origin formula function graph like:
<img width="1706" height="857" alt="45c89ebf2f614605ff0edc9ea9689980" src="https://github.com/user-attachments/assets/f3e58f7f-8b83-4c31-9831-1375f24a5fd0" />

When blue > 1382, green < -973, in the next term, blue will be -973, and green will be less than -973, over and over again. It causes smeltery's temperature becomes lower accidentally.

If we remove `radiativeHeatLoss`, the function graph will be fine like:
<img width="1750" height="702" alt="0fc2f79ccc731e274c50c1ce5bab8a83" src="https://github.com/user-attachments/assets/a262b559-6a79-413b-a73b-a446af49b3bc" />

Finally the temperature will be stopped at 20 (Room temperature)