### PR TITLE
Change hydraulic fluid loss to happen in towers instead of in machines

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/CoalFiredPurificationTower.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/CoalFiredPurificationTower.java
@@ -48,8 +48,9 @@ public class CoalFiredPurificationTower extends PylonBlock
         implements PylonFluidBufferBlock, PylonSimpleMultiblock, PylonTickingBlock, PylonGuiBlock {
 
     private static final Config settings = Settings.get(BaseKeys.COAL_FIRED_PURIFICATION_TOWER);
-    public static final double FLUID_MB_PER_SECOND = settings.getOrThrow("fluid-mb-per-second", ConfigAdapter.INT);
-    public static final double FLUID_BUFFER = settings.getOrThrow("fluid-buffer-mb", ConfigAdapter.INT);
+    public static final double PURIFICATION_SPEED = settings.getOrThrow("purification-speed", ConfigAdapter.INT);
+    public static final double PURIFICATION_EFFICIENCY = settings.getOrThrow("purification-efficiency", ConfigAdapter.DOUBLE);
+    public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.INT);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
     public static final Map<ItemStack, Integer> FUELS = new HashMap<>();
 
@@ -80,9 +81,10 @@ public class CoalFiredPurificationTower extends PylonBlock
 
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
-            return List.of(PylonArgument.of(
-                    "fluid_mb_per_second", UnitFormat.MILLIBUCKETS_PER_SECOND.format(FLUID_MB_PER_SECOND)
-            ));
+            return List.of(
+                    PylonArgument.of("purification_speed", UnitFormat.MILLIBUCKETS_PER_SECOND.format(PURIFICATION_SPEED)),
+                    PylonArgument.of("purification_efficiency", UnitFormat.PERCENT.format(PURIFICATION_EFFICIENCY * 100))
+            );
         }
     }
 
@@ -114,8 +116,8 @@ public class CoalFiredPurificationTower extends PylonBlock
         setTickInterval(TICK_INTERVAL);
         addEntity("input", FluidPointInteraction.make(context, FluidPointType.INPUT, BlockFace.NORTH));
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, FLUID_BUFFER, true, false);
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, FLUID_BUFFER, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, true, false);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -185,13 +187,20 @@ public class CoalFiredPurificationTower extends PylonBlock
         }
 
         double toPurify = Math.min(
-                deltaSeconds * FLUID_MB_PER_SECOND,
-                Math.min(fluidAmount(BaseFluids.DIRTY_HYDRAULIC_FLUID), fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID))
+                // maximum amount of dirty hydraulic fluid that can be purified this tick
+                PURIFICATION_SPEED * getTickInterval() / 20.0,
+                Math.min(
+                        // amount of dirty hydraulic fluid available
+                        fluidAmount(BaseFluids.DIRTY_HYDRAULIC_FLUID),
+                        // how much dirty hydraulic fluid can be converted without overflowing the hydraulic fluid buffer
+                        fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID) / PURIFICATION_EFFICIENCY
+                )
         );
-        removeFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, toPurify);
-        addFluid(BaseFluids.HYDRAULIC_FLUID, toPurify);
 
-        fuelSecondsElapsed += deltaSeconds;
+        removeFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, toPurify);
+        addFluid(BaseFluids.HYDRAULIC_FLUID, toPurify * PURIFICATION_EFFICIENCY);
+
+        fuelSecondsElapsed += getTickInterval() / 20.0;
         progressItem.setProgress(fuelSecondsElapsed / FUELS.get(fuel));
         if (fuelSecondsElapsed >= FUELS.get(fuel)) {
             fuel = null;
@@ -201,8 +210,9 @@ public class CoalFiredPurificationTower extends PylonBlock
 
     public boolean isRunning() {
         return fuel != null
+                // input buffer not empty
                 && fluidAmount(BaseFluids.DIRTY_HYDRAULIC_FLUID) > 1.0e-3
-                // enough space in output buffer for another tick worth of purification
-                && fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID) >= FLUID_MB_PER_SECOND * TICK_INTERVAL / 20.0;
+                // output buffer not full
+                && fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID) > 1.0e-3;
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicCoreDrill.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicCoreDrill.java
@@ -39,17 +39,14 @@ public class HydraulicCoreDrill extends CoreDrill implements PylonTickingBlock {
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             List<PylonArgument> placeholders = new ArrayList<>(super.getPlaceholders());
-            placeholders.add(PylonArgument.of("hydraulic-fluid-consumption", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_INPUT_MB_PER_SECOND)));
-            placeholders.add(PylonArgument.of("dirty-hydraulic-fluid-output", UnitFormat.MILLIBUCKETS_PER_SECOND.format(DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND)));
+            placeholders.add(PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE)));
             return placeholders;
         }
     }
 
     public static final Config settings = Settings.get(BaseKeys.HYDRAULIC_CORE_DRILL);
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", ConfigAdapter.INT);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", ConfigAdapter.INT);
-    public final double fluidConsumptionPerCycle = HYDRAULIC_FLUID_INPUT_MB_PER_SECOND * getCycleDuration() / 20.0;
-    public final double fluidOutputPerCycle = DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND * getCycleDuration() / 20.0;
+    public static final int HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.INT);
+    public final double hydraulicFluidPerCycle = HYDRAULIC_FLUID_USAGE * getCycleDuration() / 20.0;
 
     @SuppressWarnings("unused")
     public HydraulicCoreDrill(@NotNull Block block, @NotNull BlockCreateContext context) {
@@ -123,14 +120,14 @@ public class HydraulicCoreDrill extends CoreDrill implements PylonTickingBlock {
 
         Preconditions.checkState(inputHatch != null && outputHatch != null);
 
-        if (inputHatch.fluidAmount(BaseFluids.HYDRAULIC_FLUID) < fluidConsumptionPerCycle
-                || outputHatch.fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < fluidOutputPerCycle
+        if (inputHatch.fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidPerCycle
+                || outputHatch.fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidPerCycle
         ) {
             return;
         }
 
-        inputHatch.removeFluid(BaseFluids.HYDRAULIC_FLUID, fluidConsumptionPerCycle);
-        outputHatch.addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, fluidConsumptionPerCycle);
+        inputHatch.removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidPerCycle);
+        outputHatch.addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidPerCycle);
         cycle();
     }
 

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicExcavator.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicExcavator.java
@@ -48,8 +48,7 @@ public class HydraulicExcavator extends PylonBlock
                     PylonArgument.of("radius", UnitFormat.BLOCKS.format(RADIUS)),
                     PylonArgument.of("depth", UnitFormat.BLOCKS.format(DEPTH)),
                     PylonArgument.of("time-per-block", UnitFormat.SECONDS.format(BLOCK_BREAK_INTERVAL_TICKS / 20.0)),
-                    PylonArgument.of("hydraulic-fluid-consumption", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_INPUT_MB_PER_SECOND)),
-                    PylonArgument.of("dirty-hydraulic-fluid-output", UnitFormat.MILLIBUCKETS_PER_SECOND.format(DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND))
+                    PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE))
             );
         }
     }
@@ -61,10 +60,8 @@ public class HydraulicExcavator extends PylonBlock
     public static final int RADIUS = settings.getOrThrow("radius", ConfigAdapter.INT);
     public static final int DEPTH = settings.getOrThrow("depth", ConfigAdapter.INT);
     public static final int BLOCK_BREAK_INTERVAL_TICKS = settings.getOrThrow("block-break-interval-ticks", ConfigAdapter.INT);
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", ConfigAdapter.INT);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", ConfigAdapter.INT);
+    public static final int HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.INT);
     public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.DOUBLE);
-    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("dirty-hydraulic-fluid-buffer", ConfigAdapter.DOUBLE);
 
     private final List<BlockPosition> blockPositions = new ArrayList<>();
     private boolean working;
@@ -93,7 +90,7 @@ public class HydraulicExcavator extends PylonBlock
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
 
         createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_BUFFER, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, false, true);
     }
 
     @SuppressWarnings({"DataFlowIssue", "unused"})
@@ -122,11 +119,10 @@ public class HydraulicExcavator extends PylonBlock
             return;
         }
 
-        double hydraulicFluidInput = HYDRAULIC_FLUID_INPUT_MB_PER_SECOND * deltaSeconds;
-        double dirtyHydraulicFluidOutput = DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND * deltaSeconds;
+        double hydraulicFluidUsed = HYDRAULIC_FLUID_USAGE * getTickInterval() / 20.0;
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidInput
-                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < dirtyHydraulicFluidOutput
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidUsed
+                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidUsed
         ) {
             return;
         }
@@ -144,8 +140,8 @@ public class HydraulicExcavator extends PylonBlock
             }
         }
 
-        removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidInput);
-        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, dirtyHydraulicFluidOutput);
+        removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidUsed);
+        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidUsed);
     }
 
     @Override

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicFarmer.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicFarmer.java
@@ -44,8 +44,7 @@ public class HydraulicFarmer extends PylonBlock
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_FARMER);
     public static final int RADIUS = settings.getOrThrow("radius", ConfigAdapter.INT);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
-    public static final double HYDRAULIC_FLUID_MB_PER_ACTION = settings.getOrThrow("hydraulic-fluid-mb-per-action", ConfigAdapter.DOUBLE);
-    public static final double DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION = settings.getOrThrow("dirty-hydraulic-fluid-mb-per-action", ConfigAdapter.DOUBLE);
+    public static final double HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.DOUBLE);
 
     public static class Item extends PylonItem {
 
@@ -58,8 +57,7 @@ public class HydraulicFarmer extends PylonBlock
             return List.of(
                     PylonArgument.of("radius", UnitFormat.BLOCKS.format(RADIUS)),
                     PylonArgument.of("tick-interval", UnitFormat.SECONDS.format(TICK_INTERVAL / 20.0)),
-                    PylonArgument.of("hydraulic-fluid-per-action", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_MB_PER_ACTION)),
-                    PylonArgument.of("dirty-hydraulic-fluid-per-action", UnitFormat.MILLIBUCKETS.format(DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION))
+                    PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE))
             );
         }
     }
@@ -73,8 +71,8 @@ public class HydraulicFarmer extends PylonBlock
         addEntity("input", FluidPointInteraction.make(context, FluidPointType.INPUT, BlockFace.NORTH));
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
 
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_ACTION * 2, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION * 2, false, true);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_USAGE * 2, true, false);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_USAGE * 2, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -96,8 +94,10 @@ public class HydraulicFarmer extends PylonBlock
             return;
         }
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_MB_PER_ACTION
-                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION
+        double hydraulicFluidUsed = HYDRAULIC_FLUID_USAGE * getTickInterval() / 20.0;
+
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidUsed
+                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidUsed
         ) {
             return;
         }
@@ -111,8 +111,8 @@ public class HydraulicFarmer extends PylonBlock
                         && ageable.getAge() == ageable.getMaximumAge()
                 ) {
                     cropBlock.breakNaturally();
-                    removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_ACTION);
-                    addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION);
+                    removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidUsed);
+                    addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidUsed);
                     return;
                 }
             }
@@ -137,8 +137,8 @@ public class HydraulicFarmer extends PylonBlock
                 if (cropBlock.isEmpty() && farmlandBlock.getType() == Material.FARMLAND) {
                     cropBlock.setType(CROPS.get(cropToPlantStack.getType()));
                     cropToPlantStack.subtract();
-                    removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_ACTION);
-                    addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_ACTION);
+                    removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidUsed);
+                    addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidUsed);
                     return;
                 }
             }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicGrindstoneTurner.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicGrindstoneTurner.java
@@ -21,6 +21,7 @@ import io.github.pylonmc.pylon.core.i18n.PylonArgument;
 import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.util.gui.unit.UnitFormat;
 import io.github.pylonmc.pylon.core.util.position.ChunkPosition;
+import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
@@ -35,10 +36,8 @@ public class HydraulicGrindstoneTurner extends PylonBlock
         implements PylonMultiblock, PylonTickingBlock, PylonEntityHolderBlock, PylonFluidBufferBlock {
 
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_GRINDSTONE_TURNER);
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", ConfigAdapter.INT);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", ConfigAdapter.INT);
+    public static final int HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.INT);
     public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("dirty-hydraulic-fluid-buffer", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
 
@@ -49,8 +48,7 @@ public class HydraulicGrindstoneTurner extends PylonBlock
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
-                    PylonArgument.of("hydraulic_fluid_input", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_INPUT_MB_PER_SECOND)),
-                    PylonArgument.of("dirty_hydraulic_fluid_output", UnitFormat.MILLIBUCKETS_PER_SECOND.format(DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND))
+                    PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE))
             );
         }
     }
@@ -62,7 +60,7 @@ public class HydraulicGrindstoneTurner extends PylonBlock
         addEntity("input", FluidPointInteraction.make(context, FluidPointType.INPUT, BlockFace.NORTH));
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
         createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_BUFFER, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -103,17 +101,16 @@ public class HydraulicGrindstoneTurner extends PylonBlock
             return;
         }
 
-        double inputFluidAmount = nextRecipe.timeTicks() * HYDRAULIC_FLUID_INPUT_MB_PER_SECOND / 20.0;
-        double outputFluidAmount = nextRecipe.timeTicks() * DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND / 20.0;
+        double hydraulicFluidUsed = HYDRAULIC_FLUID_USAGE * nextRecipe.timeTicks() / 20.0;
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < inputFluidAmount
-                || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < outputFluidAmount
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidUsed
+                || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidUsed
                 || !grindstone.tryStartRecipe(nextRecipe, null)
         ) {
             return;
         }
 
-        removeFluid(BaseFluids.HYDRAULIC_FLUID, inputFluidAmount);
-        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, outputFluidAmount);
+        removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidUsed);
+        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidUsed);
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicHammerHead.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicHammerHead.java
@@ -54,8 +54,7 @@ public class HydraulicHammerHead extends PylonBlock
 
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_HAMMER_HEAD);
     public static final int GO_DOWN_TIME_TICKS = settings.getOrThrow("go-down-time-ticks", ConfigAdapter.INT);
-    public static final double HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("dirty-hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
+    public static final double HYDRAULIC_FLUID_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-per-craft", ConfigAdapter.INT);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
 
     private final ItemStack emptyHammerTipStack = ItemStackBuilder.of(Material.AIR)
@@ -71,8 +70,7 @@ public class HydraulicHammerHead extends PylonBlock
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
-                    PylonArgument.of("hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_MB_PER_CRAFT)),
-                    PylonArgument.of("dirty_hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT))
+                    PylonArgument.of("hydraulic-fluid-per-craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_PER_CRAFT))
             );
         }
     }
@@ -103,8 +101,8 @@ public class HydraulicHammerHead extends PylonBlock
                 .build(getBlock().getLocation().toCenterLocation().add(0, -1, 0))
         );
 
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT * 2, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT * 2, false, true);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, true, false);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -169,15 +167,15 @@ public class HydraulicHammerHead extends PylonBlock
             );
         }
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_MB_PER_CRAFT
-                || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
+                || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
                 || !hammer.tryDoRecipe(baseBlock, null)
         ) {
             return;
         }
 
-        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT);
-        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT);
+        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
+        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
 
         BaseUtils.animate(getHammerHead(), GO_DOWN_TIME_TICKS, getHeadTransformation(-0.7));
         BaseUtils.animate(getHammerTip(), GO_DOWN_TIME_TICKS, getTipTransformation(-1.7));

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicMixingAttachment.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicMixingAttachment.java
@@ -53,8 +53,7 @@ public class HydraulicMixingAttachment extends PylonBlock
     public static final int COOLDOWN_TICKS = settings.getOrThrow("cooldown-ticks", ConfigAdapter.INT);
     public static final int DOWN_ANIMATION_TIME_TICKS = settings.getOrThrow("down-animation-time-ticks", ConfigAdapter.INT);
     public static final int UP_ANIMATION_TIME_TICKS = settings.getOrThrow("up-animation-time-ticks", ConfigAdapter.INT);
-    public static final double HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("dirty-hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
+    public static final double HYDRAULIC_FLUID_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-per-craft", ConfigAdapter.INT);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
@@ -67,8 +66,7 @@ public class HydraulicMixingAttachment extends PylonBlock
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
                     PylonArgument.of("cooldown", UnitFormat.SECONDS.format(COOLDOWN_TICKS / 20.0)),
-                    PylonArgument.of("hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_MB_PER_CRAFT)),
-                    PylonArgument.of("dirty_hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT))
+                    PylonArgument.of("hydraulic-fluid-per-craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_PER_CRAFT))
             );
         }
     }
@@ -93,8 +91,8 @@ public class HydraulicMixingAttachment extends PylonBlock
                 .build(getBlock().getLocation().toCenterLocation().add(0, -1, 0))
         );
 
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT * 2, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT * 2, false, true);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, true, false);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -139,15 +137,15 @@ public class HydraulicMixingAttachment extends PylonBlock
         MixingPot mixingPot = BlockStorage.getAs(MixingPot.class, getBlock().getRelative(BlockFace.DOWN, 2));
         Preconditions.checkState(mixingPot != null);
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_MB_PER_CRAFT
-                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
+                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
                 || !mixingPot.tryDoRecipe(null)
         ) {
             return;
         }
 
-        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT);
-        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT);
+        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
+        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
 
         cooldownTimeRemaining = COOLDOWN_TICKS / 20.0;
 

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicPipeBender.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicPipeBender.java
@@ -41,10 +41,8 @@ public class HydraulicPipeBender extends PylonBlock
 
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_PIPE_BENDER);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", ConfigAdapter.INT);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", ConfigAdapter.INT);
+    public static final int HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.INT);
     public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("dirty-hydraulic-fluid-buffer", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
 
@@ -55,8 +53,7 @@ public class HydraulicPipeBender extends PylonBlock
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
-                    PylonArgument.of("hydraulic_fluid_input", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_INPUT_MB_PER_SECOND)),
-                    PylonArgument.of("dirty_hydraulic_fluid_output", UnitFormat.MILLIBUCKETS_PER_SECOND.format(DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND))
+                    PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE))
             );
         }
     }
@@ -77,7 +74,7 @@ public class HydraulicPipeBender extends PylonBlock
                 .build(block.getLocation().toCenterLocation().add(0, 0.5, 0))
         );
         createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_BUFFER, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, false, true);
         recipe = null;
     }
 
@@ -144,8 +141,8 @@ public class HydraulicPipeBender extends PylonBlock
         }
 
         for (PipeBendingRecipe recipe : PipeBendingRecipe.RECIPE_TYPE) {
-            double hydraulicFluidInput = HYDRAULIC_FLUID_INPUT_MB_PER_SECOND * recipe.timeTicks() / 20.0;
-            double dirtyHydraulicFluidOutput = DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND * recipe.timeTicks() / 20.0;
+            double hydraulicFluidInput = HYDRAULIC_FLUID_USAGE * recipe.timeTicks() / 20.0;
+            double dirtyHydraulicFluidOutput = HYDRAULIC_FLUID_USAGE * recipe.timeTicks() / 20.0;
             if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidInput
                     || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < dirtyHydraulicFluidOutput
                     || !recipe.input().matches(stack)

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicPressPiston.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicPressPiston.java
@@ -43,8 +43,7 @@ public class HydraulicPressPiston extends PylonBlock
         implements PylonMultiblock, PylonTickingBlock, PylonFluidBufferBlock, PylonEntityHolderBlock {
 
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_PRESS_PISTON);
-    public static final double HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT = settings.getOrThrow("dirty-hydraulic-fluid-mb-per-craft", ConfigAdapter.INT);
+    public static final double HYDRAULIC_FLUID_PER_CRAFT = settings.getOrThrow("hydraulic-fluid-per-craft", ConfigAdapter.INT);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
@@ -56,8 +55,7 @@ public class HydraulicPressPiston extends PylonBlock
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
-                    PylonArgument.of("hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_MB_PER_CRAFT)),
-                    PylonArgument.of("dirty_hydraulic_fluid_per_craft", UnitFormat.MILLIBUCKETS.format(DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT))
+                    PylonArgument.of("hydraulic-fluid-per-craft", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_PER_CRAFT))
             );
         }
     }
@@ -75,8 +73,8 @@ public class HydraulicPressPiston extends PylonBlock
         );
         addEntity("input", FluidPointInteraction.make(context, FluidPointType.INPUT, BlockFace.NORTH));
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT * 2, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT * 2, false, true);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, true, false);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT * 2, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -107,15 +105,15 @@ public class HydraulicPressPiston extends PylonBlock
         Press press = BlockStorage.getAs(Press.class, getBlock().getRelative(BlockFace.DOWN, 2));
         Preconditions.checkState(press != null);
 
-        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_MB_PER_CRAFT
-                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT
+        if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
+                || fluidCapacity(BaseFluids.DIRTY_HYDRAULIC_FLUID) < HYDRAULIC_FLUID_PER_CRAFT
                 || !press.tryStartRecipe(null)
         ) {
             return;
         }
 
-        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_MB_PER_CRAFT);
-        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_MB_PER_CRAFT);
+        removeFluid(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
+        addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_PER_CRAFT);
 
         BaseUtils.animate(
                 getPistonShaft(),

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicTableSaw.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/HydraulicTableSaw.java
@@ -44,10 +44,8 @@ public class HydraulicTableSaw extends PylonBlock
 
     private static final Config settings = Settings.get(BaseKeys.HYDRAULIC_TABLE_SAW);
     public static final int TICK_INTERVAL = settings.getOrThrow("tick-interval", ConfigAdapter.INT);
-    public static final int HYDRAULIC_FLUID_INPUT_MB_PER_SECOND = settings.getOrThrow("hydraulic-fluid-input-mb-per-second", ConfigAdapter.INT);
-    public static final int DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND = settings.getOrThrow("dirty-hydraulic-fluid-output-mb-per-second", ConfigAdapter.INT);
+    public static final int HYDRAULIC_FLUID_USAGE = settings.getOrThrow("hydraulic-fluid-usage", ConfigAdapter.INT);
     public static final double HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.INT);
-    public static final double DIRTY_HYDRAULIC_FLUID_BUFFER = settings.getOrThrow("dirty-hydraulic-fluid-buffer", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
 
@@ -58,8 +56,7 @@ public class HydraulicTableSaw extends PylonBlock
         @Override
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
-                    PylonArgument.of("hydraulic_fluid_input", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_INPUT_MB_PER_SECOND)),
-                    PylonArgument.of("dirty_hydraulic_fluid_output", UnitFormat.MILLIBUCKETS_PER_SECOND.format(DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND))
+                    PylonArgument.of("hydraulic-fluid-usage", UnitFormat.MILLIBUCKETS_PER_SECOND.format(HYDRAULIC_FLUID_USAGE))
             );
         }
     }
@@ -85,7 +82,7 @@ public class HydraulicTableSaw extends PylonBlock
                 .build(block.getLocation().toCenterLocation().add(0, 0.7, 0))
         );
         createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, true, false);
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, DIRTY_HYDRAULIC_FLUID_BUFFER, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, HYDRAULIC_FLUID_BUFFER, false, true);
         recipe = null;
     }
 
@@ -152,10 +149,9 @@ public class HydraulicTableSaw extends PylonBlock
         }
 
         for (TableSawRecipe recipe : TableSawRecipe.RECIPE_TYPE) {
-            double hydraulicFluidInput = recipe.timeTicks() * HYDRAULIC_FLUID_INPUT_MB_PER_SECOND;
-            double dirtyHydraulicFluidOutput = recipe.timeTicks() * DIRTY_HYDRAULIC_FLUID_OUTPUT_MB_PER_SECOND;
-            if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidInput
-                    || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < dirtyHydraulicFluidOutput
+            double hydraulicFluidUsed = recipe.timeTicks() * HYDRAULIC_FLUID_USAGE;
+            if (fluidAmount(BaseFluids.HYDRAULIC_FLUID) < hydraulicFluidUsed
+                    || fluidSpaceRemaining(BaseFluids.DIRTY_HYDRAULIC_FLUID) < hydraulicFluidUsed
                     || !PylonUtils.isPylonSimilar(stack, recipe.input())
                     || stack.getAmount() < recipe.input().getAmount()
             ) {
@@ -165,8 +161,8 @@ public class HydraulicTableSaw extends PylonBlock
             this.recipe = recipe;
             recipeTicksRemaining = recipe.timeTicks();
             spawnParticles();
-            removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidInput);
-            addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, dirtyHydraulicFluidOutput);
+            removeFluid(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidUsed);
+            addFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidUsed);
 
             break;
         }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/SolarPurificationTower.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/machines/hydraulics/SolarPurificationTower.java
@@ -28,15 +28,17 @@ import java.util.Map;
 public class SolarPurificationTower extends PylonBlock
         implements PylonSimpleMultiblock, PylonTickingBlock, PylonFluidBufferBlock {
 
-    public final double fluidMbPerSecond = getSettings().getOrThrow("fluid-mb-per-second", ConfigAdapter.DOUBLE);
-    public final double fluidBuffer = getSettings().getOrThrow("fluid-buffer-mb", ConfigAdapter.DOUBLE);
+    public final double purificationSpeed = getSettings().getOrThrow("purification-speed", ConfigAdapter.DOUBLE);
+    public final double purificationEfficiency = getSettings().getOrThrow("purification-efficiency", ConfigAdapter.DOUBLE);
+    public final double hydraulicFluidBuffer = getSettings().getOrThrow("hydraulic-fluid-buffer", ConfigAdapter.DOUBLE);
     public final double rainSpeedFraction = getSettings().getOrThrow("rain-speed-fraction", ConfigAdapter.DOUBLE);
     public final int lensLayers = getSettings().getOrThrow("lens-layers", ConfigAdapter.INT);
     public final int tickInterval = getSettings().getOrThrow("tick-interval", ConfigAdapter.INT);
 
     public static class Item extends PylonItem {
 
-        public final double fluidMbPerSecond = getSettings().getOrThrow("fluid-mb-per-second", ConfigAdapter.DOUBLE);
+        public final double purificationSpeed = getSettings().getOrThrow("purification-speed", ConfigAdapter.DOUBLE);
+        public final double purificationEfficiency = getSettings().getOrThrow("purification-efficiency", ConfigAdapter.DOUBLE);
         public final double rainSpeedFraction = getSettings().getOrThrow("rain-speed-fraction", ConfigAdapter.DOUBLE);
 
         public Item(@NotNull ItemStack stack) {
@@ -47,7 +49,8 @@ public class SolarPurificationTower extends PylonBlock
         public @NotNull List<PylonArgument> getPlaceholders() {
             return List.of(
                     PylonArgument.of("rain_speed_percentage", UnitFormat.PERCENT.format(rainSpeedFraction * 100)),
-                    PylonArgument.of("fluid_mb_per_second", UnitFormat.MILLIBUCKETS_PER_SECOND.format(fluidMbPerSecond))
+                    PylonArgument.of("purification_speed", UnitFormat.MILLIBUCKETS_PER_SECOND.format(purificationSpeed)),
+                    PylonArgument.of("purification_efficiency", UnitFormat.PERCENT.format(purificationEfficiency * 100))
             );
         }
     }
@@ -58,8 +61,8 @@ public class SolarPurificationTower extends PylonBlock
         setTickInterval(tickInterval);
         addEntity("input", FluidPointInteraction.make(context, FluidPointType.INPUT, BlockFace.NORTH));
         addEntity("output", FluidPointInteraction.make(context, FluidPointType.OUTPUT, BlockFace.SOUTH));
-        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, fluidBuffer, true, false);
-        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, fluidBuffer, false, true);
+        createFluidBuffer(BaseFluids.DIRTY_HYDRAULIC_FLUID, hydraulicFluidBuffer, true, false);
+        createFluidBuffer(BaseFluids.HYDRAULIC_FLUID, hydraulicFluidBuffer, false, true);
     }
 
     @SuppressWarnings("unused")
@@ -95,10 +98,17 @@ public class SolarPurificationTower extends PylonBlock
 
         double multiplier = getBlock().getWorld().isClearWeather() ? 1.0 : rainSpeedFraction;
         double toPurify = Math.min(
-                deltaSeconds * fluidMbPerSecond * multiplier,
-                Math.min(fluidAmount(BaseFluids.DIRTY_HYDRAULIC_FLUID), fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID))
+                // maximum amount of dirty hydraulic fluid that can be purified this tick
+                deltaSeconds * purificationSpeed * multiplier,
+                Math.min(
+                        // amount of dirty hydraulic fluid available
+                        fluidAmount(BaseFluids.DIRTY_HYDRAULIC_FLUID),
+                        // how much dirty hydraulic fluid can be converted without overflowing the hydraulic fluid buffer
+                        fluidSpaceRemaining(BaseFluids.HYDRAULIC_FLUID) / purificationEfficiency
+                )
         );
+
         removeFluid(BaseFluids.DIRTY_HYDRAULIC_FLUID, toPurify);
-        addFluid(BaseFluids.HYDRAULIC_FLUID, toPurify);
+        addFluid(BaseFluids.HYDRAULIC_FLUID, toPurify * purificationEfficiency);
     }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/tools/HydraulicCannon.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/tools/HydraulicCannon.java
@@ -35,7 +35,6 @@ public class HydraulicCannon extends PylonItem implements PylonInteractor, Hydra
     public static final double HYDRAULIC_FLUID_CAPACITY = Settings.get(BaseKeys.PORTABLE_FLUID_TANK_COPPER).getOrThrow("capacity", ConfigAdapter.DOUBLE);
     public static final double DIRTY_HYDRAULIC_FLUID_CAPACITY = Settings.get(BaseKeys.PORTABLE_FLUID_TANK_COPPER).getOrThrow("capacity", ConfigAdapter.DOUBLE);
     public static final double HYDRAULIC_FLUID_PER_SHOT = settings.getOrThrow("hydraulic-fluid-per-shot", ConfigAdapter.DOUBLE);
-    public static final double DIRTY_HYDRAULIC_FLUID_PER_SHOT = settings.getOrThrow("dirty-hydraulic-fluid-per-shot", ConfigAdapter.DOUBLE);
     public static final Material PROJECTILE_MATERIAL = settings.getOrThrow("projectile.material", ConfigAdapter.MATERIAL);
     public static final float PROJECTILE_THICKNESS = settings.getOrThrow("projectile.thickness", ConfigAdapter.FLOAT);
     public static final float PROJECTILE_LENGTH = settings.getOrThrow("projectile.length", ConfigAdapter.FLOAT);
@@ -56,7 +55,6 @@ public class HydraulicCannon extends PylonItem implements PylonInteractor, Hydra
                 PylonArgument.of("range", UnitFormat.BLOCKS.format(Math.round(PROJECTILE_SPEED_BLOCKS_PER_SECOND * PROJECTILE_LIFETIME_TICKS / 20.0))),
                 PylonArgument.of("speed", UnitFormat.BLOCKS_PER_SECOND.format(PROJECTILE_SPEED_BLOCKS_PER_SECOND)),
                 PylonArgument.of("hydraulic-fluid-per-shot", UnitFormat.MILLIBUCKETS.format(HYDRAULIC_FLUID_PER_SHOT)),
-                PylonArgument.of("dirty-hydraulic-fluid-per-shot", UnitFormat.MILLIBUCKETS.format(DIRTY_HYDRAULIC_FLUID_PER_SHOT)),
                 PylonArgument.of("hydraulic-fluid", BaseUtils.createFluidAmountBar(
                         getHydraulicFluid(),
                         HYDRAULIC_FLUID_CAPACITY,
@@ -74,7 +72,7 @@ public class HydraulicCannon extends PylonItem implements PylonInteractor, Hydra
 
     @Override
     public void onUsedToRightClick(@NotNull PlayerInteractEvent event) {
-        if (getHydraulicFluid() < HYDRAULIC_FLUID_PER_SHOT || getDirtyHydraulicFluidSpace() < DIRTY_HYDRAULIC_FLUID_PER_SHOT) {
+        if (getHydraulicFluid() < HYDRAULIC_FLUID_PER_SHOT || getDirtyHydraulicFluidSpace() < HYDRAULIC_FLUID_PER_SHOT) {
             return;
         }
 
@@ -91,7 +89,7 @@ public class HydraulicCannon extends PylonItem implements PylonInteractor, Hydra
         }
 
         setHydraulicFluid(getHydraulicFluid() - HYDRAULIC_FLUID_PER_SHOT);
-        setDirtyHydraulicFluid(getDirtyHydraulicFluid() + DIRTY_HYDRAULIC_FLUID_PER_SHOT);
+        setDirtyHydraulicFluid(getDirtyHydraulicFluid() + HYDRAULIC_FLUID_PER_SHOT);
 
         Player player = event.getPlayer();
         player.setCooldown(getStack(), COOLDOWN_TICKS);

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -809,48 +809,48 @@ item:
     name: "Hydraulic Grindstone Turner"
     lore: |-
       <arrow> Place below a constructed grindstone
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_input%
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_output%
+      <arrow> Outputs dirty hydraulic fluid
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage%
 
   hydraulic_mixing_attachment:
     name: "Hydraulic Mixing Attachment"
     lore: |-
       <arrow> Place above the mixer, leaving a one block gap
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <attr>Cooldown time:</attr> %cooldown%
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_per_craft% per craft
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_per_craft% per craft
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-per-craft% per craft
 
   hydraulic_press_piston:
     name: "Hydraulic Press Piston"
     lore: |-
       <arrow> Place above the press, leaving a one block gap
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_per_craft% per craft
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_per_craft% per craft
+      <arrow> Outputs dirty hydraulic fluid
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-per-craft% per craft
 
   hydraulic_hammer_head:
     name: "Hydraulic Hammer Head"
     lore: |-
+      <arrow> Place above the hammer's base block, leaving a two block gap
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <insn>Right click</insn> with a hammer to insert the hammer
       <arrow> <insn>Right click</insn> again to take out the hammer
-      <arrow> Place above the hammer's base block, leaving a two block gap
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_per_craft% per craft
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_per_craft% per craft
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-per-craft% per craft
 
   hydraulic_pipe_bender:
     name: "Hydraulic Pipe Bender"
     lore: |-
       <arrow> Efficiently bends materials into pipes
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <insn>Right click</insn> to insert an item
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_input%
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_output%
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage%
 
   hydraulic_table_saw:
     name: "Hydraulic Table Saw"
     lore: |-
       <arrow> Efficiently cuts logs into planks, and planks into sticks
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <insn>Right click</insn> to insert an item
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic_fluid_input% per craft
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty_hydraulic_fluid_output% per craft
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage% per craft
 
   quartz_dust:
     name: "Quartz Dust"
@@ -883,7 +883,8 @@ item:
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Only works during the day
       <arrow> Runs at %rain_speed_percentage% speed when it's raining/snowing
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.solar_purification_tower_1.name></yellow>
@@ -898,7 +899,8 @@ item:
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Only works during the day
       <arrow> Runs at %rain_speed_percentage% speed when it's raining/snowing
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.solar_purification_tower_2.name></yellow>
@@ -913,7 +915,8 @@ item:
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Only works during the day
       <arrow> Runs at %rain_speed_percentage% speed when it's raining/snowing
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.solar_purification_tower_3.name></yellow>
@@ -928,7 +931,8 @@ item:
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Only works during the day
       <arrow> Runs at %rain_speed_percentage% speed when it's raining/snowing
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.solar_purification_tower_4.name></yellow>
@@ -943,7 +947,8 @@ item:
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Only works during the day
       <arrow> Runs at %rain_speed_percentage% speed when it's raining/snowing
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.solar_purification_tower_5.name></yellow>
@@ -957,7 +962,8 @@ item:
       <star> Multiblock
       <arrow> Converts dirty hydraulic fluid back into hydraulic fluid
       <arrow> Burns coal or charcoal
-      <arrow> <attr>Purification speed:</attr> %fluid_mb_per_second%
+      <arrow> <attr>Purification speed:</attr> %purification_speed%
+      <arrow> <attr>Purification efficiency:</attr> %purification_efficiency%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.coal_fired_purification_tower.name></yellow>
@@ -1072,10 +1078,10 @@ item:
     lore: |-
       <star> Multiblock
       <arrow> Consumes hydraulic fluid to mine intermediate core chunks
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <attr>Cycle time:</attr> %cycle-time%
       <arrow> <attr>Output:</attr> %cycle-output%
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic-fluid-consumption%
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty-hydraulic-fluid-output%
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage%
       <br>
       <u>Components</u>
       <diamond> 1x <yellow><lang:pylon.pylonbase.item.hydraulic_core_drill.name></yellow>
@@ -1231,22 +1237,22 @@ item:
     name: "Hydraulic Farmer"
     lore: |-
       <arrow> Breaks crops in a radius, and replants them using seeds from the above chest
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <attr>Radius:</attr> %radius%
       <arrow> <attr>Farm interval:</attr> %tick-interval%
-      <arrow> <attr>Hydraulic fluid per action:</attr> %hydraulic-fluid-per-action%
-      <arrow> <attr>Dirty hydraulic fluid per action:</attr> %dirty-hydraulic-fluid-per-action%
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage%
 
   hydraulic_excavator:
     name: "Hydraulic Excavator"
     lore: |-
       <arrow> Excavates dirt, sand, gravel, etc in a radius beneath it
       <arrow> Cannot excavate harder blocks such as stone
+      <arrow> Outputs dirty hydraulic fluid
       <arrow> <insn>Right click</insn> to start digging
       <arrow> <attr>Radius:</attr> %radius%
       <arrow> <attr>Depth:</attr> %depth%
       <arrow> <attr>Time per block:</attr> %time-per-block%
-      <arrow> <attr>Hydraulic fluid consumption:</attr> %hydraulic-fluid-consumption%
-      <arrow> <attr>Dirty hydraulic fluid output:</attr> %dirty-hydraulic-fluid-output%
+      <arrow> <attr>Hydraulic fluid usage:</attr> %hydraulic-fluid-usage%
 
 fluid:
   castable:

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -1219,7 +1219,6 @@ item:
       <arrow> <attr>Range:</attr> %range%
       <arrow> <attr>Projectile speed:</attr> %speed%
       <arrow> <attr>Hydraulic fluid per shot:</attr> %hydraulic-fluid-per-shot%
-      <arrow> <attr>Dirty hydraulic fluid per shot:</attr> %dirty-hydraulic-fluid-per-shot%
       <arrow> <attr>Hydraulic fluid:</attr> %hydraulic-fluid%
       <arrow> <attr>Dirty hydraulic fluid:</attr> %dirty-hydraulic-fluid%
 

--- a/src/main/resources/settings/coal_fired_purification_tower.yml
+++ b/src/main/resources/settings/coal_fired_purification_tower.yml
@@ -1,7 +1,8 @@
-fluid-mb-per-second: 50
-fluid-buffer-mb: 80
+purification-speed: 50 # mb/s
+purification-efficiency: 0.93
+hydraulic-fluid-buffer: 80 # mb
 tick-interval: 20
 
 fuels:
-  coal: 15
-  charcoal: 10
+  coal: 15 # seconds
+  charcoal: 10 # seconds

--- a/src/main/resources/settings/hydraulic_cannon.yml
+++ b/src/main/resources/settings/hydraulic_cannon.yml
@@ -1,7 +1,6 @@
 cooldown-ticks: 20
 
 hydraulic-fluid-per-shot: 40
-dirty-hydraulic-fluid-per-shot: 38
 
 projectile:
     material: gray_concrete

--- a/src/main/resources/settings/hydraulic_core_drill.yml
+++ b/src/main/resources/settings/hydraulic_core_drill.yml
@@ -2,5 +2,4 @@ rotation-duration-ticks: 16 # must be a multiple of 4
 rotations-per-cycle: 20
 output: "pylonbase:intermediate_core_chunk"
 drill-material: gray_concrete
-hydraulic-fluid-input-mb-per-second: 80
-dirty-hydraulic-fluid-output-mb-per-second: 76
+hydraulic-fluid-usage: 80

--- a/src/main/resources/settings/hydraulic_excavator.yml
+++ b/src/main/resources/settings/hydraulic_excavator.yml
@@ -1,7 +1,5 @@
 block-break-interval-ticks: 40
 radius: 5
 depth: 5
-hydraulic-fluid-input-mb-per-second: 60
-dirty-hydraulic-fluid-output-mb-per-second: 57
+hydraulic-fluid-usage: 60
 hydraulic-fluid-buffer: 240
-dirty-hydraulic-fluid-buffer: 240

--- a/src/main/resources/settings/hydraulic_farmer.yml
+++ b/src/main/resources/settings/hydraulic_farmer.yml
@@ -1,4 +1,3 @@
 radius: 4
 tick-interval: 80
-hydraulic-fluid-mb-per-action: 80
-dirty-hydraulic-fluid-mb-per-action: 76
+hydraulic-fluid-usage: 80

--- a/src/main/resources/settings/hydraulic_grindstone_turner.yml
+++ b/src/main/resources/settings/hydraulic_grindstone_turner.yml
@@ -1,4 +1,2 @@
-hydraulic-fluid-input-mb-per-second: 40
-dirty-hydraulic-fluid-output-mb-per-second: 38
+hydraulic-fluid-usage: 40
 hydraulic-fluid-buffer: 800
-dirty-hydraulic-fluid-buffer: 760

--- a/src/main/resources/settings/hydraulic_hammer_head.yml
+++ b/src/main/resources/settings/hydraulic_hammer_head.yml
@@ -1,4 +1,3 @@
 tick-interval: 10
 go-down-time-ticks: 1
-hydraulic-fluid-mb-per-craft: 80
-dirty-hydraulic-fluid-mb-per-craft: 76
+hydraulic-fluid-per-craft: 80

--- a/src/main/resources/settings/hydraulic_mixing_attachment.yml
+++ b/src/main/resources/settings/hydraulic_mixing_attachment.yml
@@ -1,6 +1,5 @@
 tick-interval: 20
 cooldown-ticks: 100
-hydraulic-fluid-mb-per-craft: 200
-dirty-hydraulic-fluid-mb-per-craft: 190
+hydraulic-fluid-per-craft: 200
 down-animation-time-ticks: 3
 up-animation-time-ticks: 17

--- a/src/main/resources/settings/hydraulic_pipe_bender.yml
+++ b/src/main/resources/settings/hydraulic_pipe_bender.yml
@@ -1,5 +1,3 @@
 tick-interval: 10
-hydraulic-fluid-input-mb-per-second: 40
-dirty-hydraulic-fluid-output-mb-per-second: 38
+hydraulic-fluid-usage: 40
 hydraulic-fluid-buffer: 800
-dirty-hydraulic-fluid-buffer: 760

--- a/src/main/resources/settings/hydraulic_press_piston.yml
+++ b/src/main/resources/settings/hydraulic_press_piston.yml
@@ -1,3 +1,2 @@
 tick-interval: 10
-hydraulic-fluid-mb-per-craft: 80
-dirty-hydraulic-fluid-mb-per-craft: 76
+hydraulic-fluid-per-craft: 80

--- a/src/main/resources/settings/hydraulic_table_saw.yml
+++ b/src/main/resources/settings/hydraulic_table_saw.yml
@@ -1,5 +1,3 @@
 tick-interval: 10
-hydraulic-fluid-input-mb-per-second: 20
-dirty-hydraulic-fluid-output-mb-per-second: 19
+hydraulic-fluid-usage: 20
 hydraulic-fluid-buffer: 400
-dirty-hydraulic-fluid-buffer: 380

--- a/src/main/resources/settings/solar_purification_tower_1.yml
+++ b/src/main/resources/settings/solar_purification_tower_1.yml
@@ -1,5 +1,6 @@
-fluid-mb-per-second: 16
-fluid-buffer-mb: 64
+purification-speed: 16 # mb/s
+purification-efficiency: 0.90
+hydraulic-fluid-buffer: 64 # mb
 rain-speed-fraction: 0.6
 lens-layers: 1
 tick-interval: 40

--- a/src/main/resources/settings/solar_purification_tower_2.yml
+++ b/src/main/resources/settings/solar_purification_tower_2.yml
@@ -1,5 +1,6 @@
-fluid-mb-per-second: 60
-fluid-buffer-mb: 240
+purification-speed: 60 # mb/s
+purification-efficiency: 0.92
+hydraulic-fluid-buffer: 240 # mb
 rain-speed-fraction: 0.6
 lens-layers: 2
 tick-interval: 40

--- a/src/main/resources/settings/solar_purification_tower_3.yml
+++ b/src/main/resources/settings/solar_purification_tower_3.yml
@@ -1,5 +1,6 @@
-fluid-mb-per-second: 140
-fluid-buffer-mb: 560
+purification-speed: 240 # mb/s
+purification-efficiency: 0.94
+hydraulic-fluid-buffer: 560 # mb
 rain-speed-fraction: 0.6
 lens-layers: 3
 tick-interval: 40

--- a/src/main/resources/settings/solar_purification_tower_4.yml
+++ b/src/main/resources/settings/solar_purification_tower_4.yml
@@ -1,5 +1,6 @@
-fluid-mb-per-second: 300
-fluid-buffer-mb: 1200
+purification-speed: 300 # mb/s
+purification-efficiency: 0.96
+hydraulic-fluid-buffer: 1200 # mb
 rain-speed-fraction: 0.6
 lens-layers: 4
 tick-interval: 40

--- a/src/main/resources/settings/solar_purification_tower_5.yml
+++ b/src/main/resources/settings/solar_purification_tower_5.yml
@@ -1,5 +1,6 @@
-fluid-mb-per-second: 400
-fluid-buffer-mb: 1600
+purification-speed: 400 # mb/s
+purification-efficiency: 0.98
+hydraulic-fluid-buffer: 1600 # mb
 rain-speed-fraction: 0.6
 lens-layers: 5
 tick-interval: 40


### PR DESCRIPTION
- Unifies the 'hydraulic fluid input' and 'dirty hydraulic fluid output' quantities into one 'hydraulic fluid usage' for machines. Machines no longer lose some hydraulic fluid when working
- Updates lore of machines to reflect this
- Adds conversion efficiency to purification towers to show how much fluid they'll lose when purifying
- Removes deltaSeconds usage for all the hydraulic machines