### PR TITLE
[ref:fix-build] Migrate drilling and molding recipes

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/BaseItems.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/BaseItems.java
@@ -16,12 +16,9 @@ import io.github.pylonmc.pylon.base.content.machines.simple.Press;
 import io.github.pylonmc.pylon.base.content.machines.simple.VacuumHopper;
 import io.github.pylonmc.pylon.base.content.machines.smelting.PitKiln;
 import io.github.pylonmc.pylon.base.content.tools.FireproofRune;
-import io.github.pylonmc.pylon.base.content.resources.RefractoryMix;
 import io.github.pylonmc.pylon.base.content.science.Loupe;
 import io.github.pylonmc.pylon.base.content.science.ResearchPack;
 import io.github.pylonmc.pylon.base.content.tools.*;
-import io.github.pylonmc.pylon.base.recipes.display.DrillingDisplayRecipe;
-import io.github.pylonmc.pylon.base.recipes.display.MoldingDisplayRecipe;
 import io.github.pylonmc.pylon.core.config.Settings;
 import io.github.pylonmc.pylon.core.config.adapter.ConfigAdapter;
 import io.github.pylonmc.pylon.core.content.fluid.FluidPipe;
@@ -29,7 +26,6 @@ import io.github.pylonmc.pylon.core.content.guide.PylonGuide;
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers;
 import io.github.pylonmc.pylon.core.item.PylonItem;
 import io.github.pylonmc.pylon.core.item.builder.ItemStackBuilder;
-import io.github.pylonmc.pylon.core.recipe.DisplayRecipeType;
 import io.github.pylonmc.pylon.core.recipe.RecipeType;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.*;
@@ -1387,13 +1383,6 @@ public final class BaseItems {
     static {
         PylonItem.register(PylonItem.class, UNFIRED_REFRACTORY_BRICK, BaseKeys.UNFIRED_REFRACTORY_BRICK);
         BasePages.RESOURCES.addItem(UNFIRED_REFRACTORY_BRICK);
-
-        DisplayRecipeType.INSTANCE.addRecipe(new MoldingDisplayRecipe(
-                BaseKeys.UNFIRED_REFRACTORY_BRICK,
-                REFRACTORY_MIX,
-                UNFIRED_REFRACTORY_BRICK,
-                RefractoryMix.TOTAL_MOLDING_CLICKS
-        ));
     }
 
     public static final ItemStack REFRACTORY_BRICK = ItemStackBuilder.pylonItem(Material.NETHERITE_INGOT, BaseKeys.REFRACTORY_BRICK)
@@ -1656,6 +1645,28 @@ public final class BaseItems {
         BasePages.TOOLS.addItem(FIREPROOF_RUNE);
     }
 
+
+    public static final ItemStack SHALLOW_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.SHALLOW_CORE_CHUNK)
+            .build();
+    static {
+        PylonItem.register(PylonItem.class, SHALLOW_CORE_CHUNK, BaseKeys.SHALLOW_CORE_CHUNK);
+        BasePages.RESOURCES.addItem(SHALLOW_CORE_CHUNK);
+    }
+
+    public static final ItemStack SUBSURFACE_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.SUBSURFACE_CORE_CHUNK)
+            .build();
+    static {
+        PylonItem.register(PylonItem.class, SUBSURFACE_CORE_CHUNK, BaseKeys.SUBSURFACE_CORE_CHUNK);
+        BasePages.RESOURCES.addItem(SUBSURFACE_CORE_CHUNK);
+    }
+
+    public static final ItemStack INTERMEDIATE_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.INTERMEDIATE_CORE_CHUNK)
+            .build();
+    static {
+        PylonItem.register(PylonItem.class, INTERMEDIATE_CORE_CHUNK, BaseKeys.INTERMEDIATE_CORE_CHUNK);
+        BasePages.RESOURCES.addItem(INTERMEDIATE_CORE_CHUNK);
+    }
+
     public static final ItemStack MANUAL_CORE_DRILL_LEVER = ItemStackBuilder.pylonItem(Material.LEVER, BaseKeys.MANUAL_CORE_DRILL_LEVER)
             .build();
     static {
@@ -1698,44 +1709,6 @@ public final class BaseItems {
         BasePages.HYDRAULICS.addItem(HYDRAULIC_CORE_DRILL_OUTPUT_HATCH);
     }
 
-    public static final ItemStack SHALLOW_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.SHALLOW_CORE_CHUNK)
-            .build();
-    static {
-        PylonItem.register(PylonItem.class, SHALLOW_CORE_CHUNK, BaseKeys.SHALLOW_CORE_CHUNK);
-        BasePages.RESOURCES.addItem(SHALLOW_CORE_CHUNK);
-
-        DisplayRecipeType.INSTANCE.addRecipe(new DrillingDisplayRecipe(
-                BaseKeys.SHALLOW_CORE_CHUNK,
-                MANUAL_CORE_DRILL,
-                SHALLOW_CORE_CHUNK
-        ));
-    }
-
-    public static final ItemStack SUBSURFACE_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.SUBSURFACE_CORE_CHUNK)
-            .build();
-    static {
-        PylonItem.register(PylonItem.class, SUBSURFACE_CORE_CHUNK, BaseKeys.SUBSURFACE_CORE_CHUNK);
-        BasePages.RESOURCES.addItem(SUBSURFACE_CORE_CHUNK);
-
-        DisplayRecipeType.INSTANCE.addRecipe(new DrillingDisplayRecipe(
-                BaseKeys.SUBSURFACE_CORE_CHUNK,
-                IMPROVED_MANUAL_CORE_DRILL,
-                SUBSURFACE_CORE_CHUNK
-        ));
-    }
-
-    public static final ItemStack INTERMEDIATE_CORE_CHUNK = ItemStackBuilder.pylonItem(Material.FIREWORK_STAR, BaseKeys.INTERMEDIATE_CORE_CHUNK)
-            .build();
-    static {
-        PylonItem.register(PylonItem.class, INTERMEDIATE_CORE_CHUNK, BaseKeys.INTERMEDIATE_CORE_CHUNK);
-        BasePages.RESOURCES.addItem(INTERMEDIATE_CORE_CHUNK);
-
-        DisplayRecipeType.INSTANCE.addRecipe(new DrillingDisplayRecipe(
-                BaseKeys.INTERMEDIATE_CORE_CHUNK,
-                HYDRAULIC_CORE_DRILL,
-                INTERMEDIATE_CORE_CHUNK
-        ));
-    }
     public static final ItemStack REACTIVATED_WITHER_SKULL = ItemStackBuilder.pylonItem(Material.WITHER_SKELETON_SKULL, BaseKeys.REACTIVATED_WITHER_SKULL)
             .set(DataComponentTypes.MAX_DAMAGE, Settings.get(BaseKeys.REACTIVATED_WITHER_SKULL).getOrThrow("durability", ConfigAdapter.INT))
             .set(DataComponentTypes.DAMAGE, 0)

--- a/src/main/java/io/github/pylonmc/pylon/base/BaseRecipes.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/BaseRecipes.java
@@ -11,6 +11,8 @@ public class BaseRecipes {
     public static void initialize() {
         CastingRecipe.RECIPE_TYPE.register();
 
+        DrillingDisplayRecipe.RECIPE_TYPE.register();
+
         GrindstoneRecipe.RECIPE_TYPE.register();
 
         HammerRecipe.RECIPE_TYPE.register();
@@ -20,6 +22,8 @@ public class BaseRecipes {
         MeltingRecipe.RECIPE_TYPE.register();
 
         MixingPotRecipe.RECIPE_TYPE.register();
+
+        MoldingRecipe.RECIPE_TYPE.register();
 
         PipeBendingRecipe.RECIPE_TYPE.register();
 

--- a/src/main/java/io/github/pylonmc/pylon/base/content/resources/RefractoryMix.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/resources/RefractoryMix.java
@@ -1,20 +1,15 @@
 package io.github.pylonmc.pylon.base.content.resources;
 
-import io.github.pylonmc.pylon.base.BaseItems;
-import io.github.pylonmc.pylon.base.BaseKeys;
 import io.github.pylonmc.pylon.base.content.tools.Moldable;
 import io.github.pylonmc.pylon.core.block.PylonBlock;
 import io.github.pylonmc.pylon.core.block.context.BlockCreateContext;
 import io.github.pylonmc.pylon.core.block.waila.WailaConfig;
-import io.github.pylonmc.pylon.core.config.Settings;
-import io.github.pylonmc.pylon.core.config.adapter.ConfigAdapter;
 import io.github.pylonmc.pylon.core.datatypes.PylonSerializers;
 import io.github.pylonmc.pylon.core.i18n.PylonArgument;
 import io.github.pylonmc.pylon.core.util.gui.unit.UnitFormat;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,15 +21,13 @@ public class RefractoryMix extends PylonBlock implements Moldable {
 
     private static final NamespacedKey MOLDING_CLICKS_KEY = baseKey("molding-clicks");
 
-    public static final int TOTAL_MOLDING_CLICKS = Settings.get(BaseKeys.REFRACTORY_MIX).getOrThrow("total-molding-clicks", ConfigAdapter.INT);
-
     private int moldingClicksRemaining;
 
 
     @SuppressWarnings("unused")
     public RefractoryMix(@NotNull Block block, @NotNull BlockCreateContext context) {
         super(block, context);
-        moldingClicksRemaining = TOTAL_MOLDING_CLICKS;
+        moldingClicksRemaining = totalMoldingClicks();
     }
 
     @SuppressWarnings("unused")
@@ -59,16 +52,11 @@ public class RefractoryMix extends PylonBlock implements Moldable {
     }
 
     @Override
-    public ItemStack moldingResult() {
-        return BaseItems.UNFIRED_REFRACTORY_BRICK;
-    }
-
-    @Override
     public @Nullable WailaConfig getWaila(@NotNull Player player) {
         return new WailaConfig(getDefaultWailaTranslationKey().arguments(
                 PylonArgument.of(
                         "percent",
-                        UnitFormat.PERCENT.format(100 * (TOTAL_MOLDING_CLICKS - moldingClicksRemaining) / TOTAL_MOLDING_CLICKS)
+                        UnitFormat.PERCENT.format(100 * (totalMoldingClicks() - moldingClicksRemaining) / totalMoldingClicks())
                 )
         ));
     }

--- a/src/main/java/io/github/pylonmc/pylon/base/content/tools/Moldable.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/content/tools/Moldable.java
@@ -1,10 +1,34 @@
 package io.github.pylonmc.pylon.base.content.tools;
 
+import io.github.pylonmc.pylon.base.recipes.MoldingRecipe;
+import io.github.pylonmc.pylon.core.registry.PylonRegistry;
+import org.bukkit.Keyed;
 import org.bukkit.inventory.ItemStack;
 
 
-public interface Moldable {
+public interface Moldable extends Keyed {
     void doMoldingClick();
     boolean isMoldingFinished();
-    ItemStack moldingResult();
+
+    default ItemStack moldingInputStack() {
+        return PylonRegistry.ITEMS.getOrThrow(getKey()).getItemStack();
+    }
+
+    default ItemStack moldingResult() {
+        for (MoldingRecipe recipe : MoldingRecipe.RECIPE_TYPE) {
+            if (recipe.isInput(moldingInputStack())) {
+                return recipe.result();
+            }
+        }
+        throw new IllegalStateException("Moldable item " + getKey() + " does not have an associated molding recipe");
+    }
+
+    default int totalMoldingClicks() {
+        for (MoldingRecipe recipe : MoldingRecipe.RECIPE_TYPE) {
+            if (recipe.isInput(moldingInputStack())) {
+                return recipe.moldClicks();
+            }
+        }
+        throw new IllegalStateException("Moldable item " + getKey() + " does not have an associated molding recipe");
+    }
 }

--- a/src/main/java/io/github/pylonmc/pylon/base/recipes/DrillingDisplayRecipe.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/recipes/DrillingDisplayRecipe.java
@@ -1,8 +1,12 @@
-package io.github.pylonmc.pylon.base.recipes.display;
+package io.github.pylonmc.pylon.base.recipes;
 
+import io.github.pylonmc.pylon.core.config.ConfigSection;
+import io.github.pylonmc.pylon.core.config.adapter.ConfigAdapter;
+import io.github.pylonmc.pylon.core.recipe.ConfigurableRecipeType;
 import io.github.pylonmc.pylon.core.recipe.FluidOrItem;
 import io.github.pylonmc.pylon.core.recipe.PylonRecipe;
 import io.github.pylonmc.pylon.core.recipe.RecipeInput;
+import io.github.pylonmc.pylon.core.recipe.RecipeType;
 import io.github.pylonmc.pylon.core.util.gui.GuiItems;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -11,12 +15,25 @@ import xyz.xenondevs.invui.gui.Gui;
 
 import java.util.List;
 
-// TODO use DisplayRecipeType
+import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
+
+
 public record DrillingDisplayRecipe(
         NamespacedKey key,
         ItemStack drill,
         ItemStack result
 ) implements PylonRecipe {
+
+    public static final RecipeType<DrillingDisplayRecipe> RECIPE_TYPE = new ConfigurableRecipeType<>(baseKey("drilling_display_recipe")) {
+        @Override
+        protected @NotNull DrillingDisplayRecipe loadRecipe(@NotNull NamespacedKey key, @NotNull ConfigSection section) {
+            return new DrillingDisplayRecipe(
+                    key,
+                    section.getOrThrow("drill", ConfigAdapter.ITEM_STACK),
+                    section.getOrThrow("result", ConfigAdapter.ITEM_STACK)
+            );
+        }
+    };
 
     @Override
     public @NotNull NamespacedKey getKey() {

--- a/src/main/java/io/github/pylonmc/pylon/base/recipes/MoldingRecipe.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/recipes/MoldingRecipe.java
@@ -1,9 +1,13 @@
-package io.github.pylonmc.pylon.base.recipes.display;
+package io.github.pylonmc.pylon.base.recipes;
 
 import io.github.pylonmc.pylon.base.BaseItems;
+import io.github.pylonmc.pylon.core.config.ConfigSection;
+import io.github.pylonmc.pylon.core.config.adapter.ConfigAdapter;
+import io.github.pylonmc.pylon.core.recipe.ConfigurableRecipeType;
 import io.github.pylonmc.pylon.core.recipe.FluidOrItem;
 import io.github.pylonmc.pylon.core.recipe.PylonRecipe;
 import io.github.pylonmc.pylon.core.recipe.RecipeInput;
+import io.github.pylonmc.pylon.core.recipe.RecipeType;
 import io.github.pylonmc.pylon.core.util.gui.GuiItems;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -12,13 +16,27 @@ import xyz.xenondevs.invui.gui.Gui;
 
 import java.util.List;
 
-// TODO use DisplayRecipeType
-public record MoldingDisplayRecipe(
+import static io.github.pylonmc.pylon.base.util.BaseUtils.baseKey;
+
+
+public record MoldingRecipe(
         NamespacedKey key,
         ItemStack input,
         ItemStack result,
         int moldClicks
 ) implements PylonRecipe {
+
+    public static final RecipeType<MoldingRecipe> RECIPE_TYPE = new ConfigurableRecipeType<>(baseKey("molding")) {
+        @Override
+        protected @NotNull MoldingRecipe loadRecipe(@NotNull NamespacedKey key, @NotNull ConfigSection section) {
+            return new MoldingRecipe(
+                    key,
+                    section.getOrThrow("input", ConfigAdapter.ITEM_STACK),
+                    section.getOrThrow("result", ConfigAdapter.ITEM_STACK),
+                    section.getOrThrow("clicks", ConfigAdapter.INT)
+            );
+        }
+    };
 
     @Override
     public @NotNull NamespacedKey getKey() {
@@ -27,7 +45,7 @@ public record MoldingDisplayRecipe(
 
     @Override
     public @NotNull List<@NotNull RecipeInput> getInputs() {
-        return List.of();
+        return List.of(RecipeInput.of(input));
     }
 
     @Override

--- a/src/main/resources/recipes/pylonbase/drill_display.yml
+++ b/src/main/resources/recipes/pylonbase/drill_display.yml
@@ -1,0 +1,15 @@
+# WARNING!
+# Modifying this file does not change the actual underlying recipes.
+# The recipes in this file are only displayed in the guide.
+
+pylonbase:shallow_core_chunk:
+  drill: pylonbase:manual_core_drill
+  result: pylonbase:shallow_core_chunk
+
+pylonbase:subsurface_core_chunk:
+  drill: pylonbase:improved_manual_core_drill
+  result: pylonbase:subsurface_core_chunk
+
+pylonbase:intermediate_core_chunk:
+  drill: pylonbase:hydraulic_core_drill
+  result: pylonbase:intermediate_core_chunk

--- a/src/main/resources/recipes/pylonbase/molding.yml
+++ b/src/main/resources/recipes/pylonbase/molding.yml
@@ -1,0 +1,4 @@
+pylonbase:unfired_refractory_brick:
+  input: pylonbase:refractory_mix
+  result: pylonbase:unfired_refractory_brick
+  clicks: 4

--- a/src/main/resources/settings/refractory_mix.yml
+++ b/src/main/resources/settings/refractory_mix.yml
@@ -1,1 +1,0 @@
-total-molding-clicks: 4


### PR DESCRIPTION
Change drilling recipe to use config files. This removes the circular dependency in BaseItems between core chunks and core drills. The recipe is still purely for display. I have added a comment in the file to indicate this.

Change molding recipe to also use config files and changed molding mechanic to actually respect the recipe. This allows us to also migrate this to config files instead of having it in BaseItems.
