### PR TITLE
Fix Smeltery Recipe Collisions

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/base/BaseFluids.java
+++ b/src/main/java/io/github/pylonmc/pylon/base/BaseFluids.java
@@ -286,7 +286,7 @@ public final class BaseFluids {
         ));
 
         MeltingRecipe.RECIPE_TYPE.addRecipe(new MeltingRecipe(
-                NamespacedKey.fromString(fluid.getKey() + "from_dust"),
+                NamespacedKey.fromString(fluid.getKey() + "_from_dust"),
                 RecipeInput.of(dust),
                 fluid,
                 144.0,


### PR DESCRIPTION
Currently you can only smelt the metal block in the smeltery because all of them have the same id, this remedies that for now until I move the recipes to the config system later