### PR TITLE
Fix hydraulic cannon's lore having a space before damage

### DIFF
--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -1234,7 +1234,7 @@ item:
       <arrow> Refuel using the <white>Hydraulic Refueling Station
       <arrow> <insn>Right click</insn> to fire
       <arrow> <attr>Cooldown:</attr> %cooldown%
-      <arrow> <attr>Damage: </attr> %damage%
+      <arrow> <attr>Damage:</attr> %damage%
       <arrow> <attr>Range:</attr> %range%
       <arrow> <attr>Projectile speed:</attr> %speed%
       <arrow> <attr>Hydraulic fluid per shot:</attr> %hydraulic-fluid-per-shot%


### PR DESCRIPTION
Resolves #420 

self explanatory