### PR TITLE
fix(guide): show lowest tier recipe first for drilling display

### DIFF
--- a/src/main/resources/recipes/pylon/grindstone.yml
+++ b/src/main/resources/recipes/pylon/grindstone.yml
@@ -9,6 +9,7 @@ pylon:shallow_core_chunk:
       weight: 0.3
   cycles: 6
   particle-data: minecraft:stone
+  priority: 3
 
 pylon:subsurface_core_chunk:
   input: pylon:subsurface_core_chunk
@@ -27,6 +28,7 @@ pylon:subsurface_core_chunk:
       weight: 0.4
   cycles: 8
   particle-data: minecraft:stone
+  priority: 2
 
 pylon:intermediate_core_chunk:
   input: pylon:intermediate_core_chunk
@@ -49,6 +51,7 @@ pylon:intermediate_core_chunk:
       weight: 0.1
   cycles: 10
   particle-data: minecraft:stone
+  priority: 1
 
 pylon:rock_dust:
   input: "#rebar:rocks"


### PR DESCRIPTION
Reordered core chunk recipe priorities in the guide display. Previously, higher-tier recipes like 'intermediate core chunk' appeared first when researching materials like tin, which was confusing for new players.

By setting the lowest tier (shallow) to priority 1 and the highest tier (intermediate) to 3, the guide now opens to the most accessible recipe by default.

Fixes #650