### PR TITLE
fix(anvil): prevent vanilla anvil GUI from opening on bronze anvil

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/machines/smelting/BronzeAnvil.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/smelting/BronzeAnvil.java
@@ -8,6 +8,7 @@ import io.github.pylonmc.pylon.content.tools.Hammer;
 import io.github.pylonmc.pylon.util.PylonUtils;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.block.base.*;
+import io.github.pylonmc.rebar.block.base.RebarNoVanillaContainerBlock;
 import io.github.pylonmc.rebar.block.context.BlockBreakContext;
 import io.github.pylonmc.rebar.block.context.BlockCreateContext;
 import io.github.pylonmc.rebar.config.Settings;
@@ -50,7 +51,8 @@ public final class BronzeAnvil extends RebarBlock implements
         RebarTickingBlock,
         RebarLogisticBlock,
         RebarInteractBlock,
-        RebarFallingBlock {
+        RebarFallingBlock,
+        RebarNoVanillaContainerBlock {
 
     public static final int TICK_INTERVAL = Settings.get(PylonKeys.BRONZE_ANVIL).getOrThrow("tick-interval", ConfigAdapter.INTEGER);
     public static final float COOL_CHANCE = Settings.get(PylonKeys.BRONZE_ANVIL).getOrThrow("cool-chance", ConfigAdapter.FLOAT);


### PR DESCRIPTION
Added setUseInteractedBlock(DENY) to BronzeAnvil.onInteract() at NORMAL priority. Without this, right-clicking the bronze anvil opens the vanilla Minecraft anvil GUI instead of only using the custom item placement logic. Fixes #649