### PR TITLE
fix: fix loupe entity discovery message key (#612)

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/science/Loupe.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/science/Loupe.java
@@ -279,7 +279,7 @@ public final class Loupe extends RebarItem implements RebarInteractor, RebarCons
             }
 
             markAlreadyExamined(player, entity);
-            addEntry(player, entityArg, entity.getType().getKey(), getEntryConfig(entity.getType()));
+            addEntry(player, Component.translatable(entity.getType().translationKey()), entity.getType().getKey(), getEntryConfig(entity.getType()));
             //player.setCooldown(getStack(), cooldownTicks);
         } else if (scan.getHitBlock() != null) {
             Block hit = scan.getHitBlock();


### PR DESCRIPTION
Entity discovery was showing 'rebar:objectHorse' because entityArg (a RebarArgument) was passed to addEntry(), which double-wrapped the component. Now passes the raw Component directly, matching the behavior for blocks and items. Fixes #612