### PR TITLE
fix(talisman): prevent instant saturation exploit on hunger talisman

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/talismans/HungerTalisman.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/talismans/HungerTalisman.java
@@ -59,7 +59,7 @@ public class HungerTalisman extends Talisman {
         hungerTasks.put(player.getUniqueId(), Bukkit.getScheduler().runTaskTimer(Pylon.getInstance(), () -> {
             player.setFoodLevel(Math.min(player.getFoodLevel() + hungerIncrease, 20));
             player.setSaturation(Math.min(player.getSaturation() + saturationIncrease, player.getFoodLevel()));
-        }, 0, increasePeriod));
+        }, increasePeriod, increasePeriod));
     }
 
     @Override


### PR DESCRIPTION
The Hunger Talisman previously initialized its saturation recovery Bukkit task with a 0-tick initial delay. Players exploited this by repeatedly dropping and picking up the talisman to trigger the instant first execution, bypassing the intended cooldown period entirely.

Fixed by assigning `increasePeriod` as the initial delay for the runTaskTimer instead of 0. Players must now wait the full duration before receiving their first saturation tick upon equipping the talisman. Fixes #698

Testing:

https://github.com/user-attachments/assets/297af9a7-79a6-4aad-8236-69be3b2a169e
