### PR TITLE
fix: jitpack issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -125,6 +125,12 @@ signing {
     sign(publishing.publications["maven"])
 }
 
+tasks.withType(Sign::class) {
+    onlyIf {
+        System.getenv("SIGNING_KEY") != null && System.getenv("SIGNING_PASSWORD") != null
+    }
+}
+
 nmcpAggregation {
     centralPortal {
         username = System.getenv("SONATYPE_USERNAME")


### PR DESCRIPTION
only run the signing task when signing credentials exist, this would resolve local publishing issues, as well as on jitpack