### PR TITLE
[ref:human/block-stuff] FluidTank/FluidHatch Ghost Block

### DIFF
--- a/src/main/java/io/github/pylonmc/pylon/content/components/FluidHatch.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/components/FluidHatch.java
@@ -3,6 +3,7 @@ package io.github.pylonmc.pylon.content.components;
 import com.google.common.base.Preconditions;
 import io.github.pylonmc.pylon.Pylon;
 import io.github.pylonmc.pylon.content.machines.fluid.FluidTankCasing;
+import io.github.pylonmc.pylon.content.machines.fluid.multiblock.FluidTankCasingComponent;
 import io.github.pylonmc.pylon.util.PylonUtils;
 import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.RebarBlock;
@@ -49,23 +50,7 @@ public abstract class FluidHatch extends RebarBlock implements
         RebarDirectionalBlock {
 
     private static final NamespacedKey FLUID_KEY = pylonKey("fluid");
-
-    private static MultiblockComponent component;
-
     public @Nullable RebarFluid fluid;
-
-    static {
-        // run on first tick after all addons registered
-        Bukkit.getScheduler().runTaskLater(Pylon.getInstance(), () -> {
-            List<NamespacedKey> components = new ArrayList<>();
-            for (RebarItemSchema schema : RebarRegistry.ITEMS) {
-                if (FluidTankCasing.Item.class.isAssignableFrom(schema.getItemClass())) {
-                    components.add(schema.getKey());
-                }
-            }
-            component = MultiblockComponent.of(components.toArray(new NamespacedKey[0]));
-        }, 0);
-    }
 
     public FluidHatch(@NotNull Block block, @NotNull BlockCreateContext context) {
         super(block, context);
@@ -90,7 +75,7 @@ public abstract class FluidHatch extends RebarBlock implements
     @Override
     public @NotNull Map<Vector3i, MultiblockComponent> getComponents() {
         Map<Vector3i, MultiblockComponent> components = new HashMap<>();
-        components.put(new Vector3i(0, 1, 0), component);
+        components.put(new Vector3i(0, 1, 0), FluidTankCasingComponent.INSTANCE);
         return components;
     }
 

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/FluidTank.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/FluidTank.java
@@ -1,9 +1,11 @@
 package io.github.pylonmc.pylon.content.machines.fluid;
 
+import io.github.pylonmc.pylon.content.machines.fluid.multiblock.FluidTankCasingComponent;
 import io.github.pylonmc.pylon.util.PylonUtils;
 import io.github.pylonmc.rebar.block.BlockStorage;
 import io.github.pylonmc.rebar.block.RebarBlock;
 import io.github.pylonmc.rebar.block.base.RebarDirectionalBlock;
+import io.github.pylonmc.rebar.block.base.RebarGhostBlockHolder;
 import io.github.pylonmc.rebar.block.base.RebarMultiblock;
 import io.github.pylonmc.rebar.block.context.BlockCreateContext;
 import io.github.pylonmc.rebar.config.adapter.ConfigAdapter;
@@ -28,13 +30,16 @@ import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.util.Vector;
 import org.jetbrains.annotations.NotNull;
 import org.joml.Vector3d;
+import org.joml.Vector3i;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
 public class FluidTank extends RebarBlock
-        implements RebarMultiblock, FluidTankWithDisplayEntity, RebarDirectionalBlock {
+        implements RebarMultiblock, FluidTankWithDisplayEntity, RebarDirectionalBlock, RebarGhostBlockHolder {
+
+    private static final Vector3i CASING_POSITION = new Vector3i(0, 1, 0);
 
     private final int maxHeight = getSettings().getOrThrow("max-height", ConfigAdapter.INTEGER);
 
@@ -66,6 +71,7 @@ public class FluidTank extends RebarBlock
         );
         createFluidPoint(FluidPointType.INPUT, BlockFace.NORTH, context, false);
         createFluidPoint(FluidPointType.OUTPUT, BlockFace.SOUTH, context, false);
+        FluidTankCasingComponent.INSTANCE.spawnGhostBlock(this, CASING_POSITION);
     }
 
     @SuppressWarnings("unused")
@@ -95,11 +101,15 @@ public class FluidTank extends RebarBlock
 
             casings.add(casing);
         }
+
+        FluidTankCasingComponent.INSTANCE.updateGhostBlock(this, CASING_POSITION);
+
         return !casings.isEmpty();
     }
 
     @Override
     public void onMultiblockFormed() {
+        removeGhostBlock(CASING_POSITION);
         onMultiblockRefreshed();
     }
 
@@ -128,6 +138,10 @@ public class FluidTank extends RebarBlock
 
     @Override
     public void onMultiblockUnformed(boolean partUnloaded) {
+        if (!partUnloaded) {
+            FluidTankCasingComponent.INSTANCE.spawnGhostBlock(this, CASING_POSITION);
+        }
+
         casings.forEach(FluidTankCasing::reset);
         casings.clear();
         allowedTemperatures.clear();

--- a/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/multiblock/FluidTankCasingComponent.java
+++ b/src/main/java/io/github/pylonmc/pylon/content/machines/fluid/multiblock/FluidTankCasingComponent.java
@@ -1,0 +1,38 @@
+package io.github.pylonmc.pylon.content.machines.fluid.multiblock;
+
+import io.github.pylonmc.pylon.Pylon;
+import io.github.pylonmc.pylon.content.machines.fluid.FluidTankCasing;
+import io.github.pylonmc.rebar.block.RebarBlockSchema;
+import io.github.pylonmc.rebar.block.base.RebarSimpleMultiblock;
+import io.github.pylonmc.rebar.event.RebarRegisterEvent;
+import io.github.pylonmc.rebar.registry.RebarRegistry;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FluidTankCasingComponent extends RebarSimpleMultiblock.MultiblockComponent {
+    private static final List<NamespacedKey> FLUID_TANK_CASING_IDS = new ArrayList<>(RebarRegistry.BLOCKS.stream()
+            .filter(schema -> schema.isType(FluidTankCasing.class))
+            .map(RebarBlockSchema::getKey)
+            .toList());
+
+    public static final FluidTankCasingComponent INSTANCE = new FluidTankCasingComponent();
+
+    private FluidTankCasingComponent() {
+        super(List.of(), FLUID_TANK_CASING_IDS);
+        Bukkit.getPluginManager().registerEvents(new RegistryListener(), Pylon.getInstance());
+    }
+
+    public static class RegistryListener implements Listener {
+        @EventHandler
+        public void onRegister(RebarRegisterEvent event) {
+            if (event.getValue() instanceof RebarBlockSchema schema && schema.isType(FluidTankCasing.class) && !FLUID_TANK_CASING_IDS.contains(schema.getKey())) {
+                FLUID_TANK_CASING_IDS.add(schema.getKey());
+            }
+        }
+    }
+}


### PR DESCRIPTION
extract the casing multiblock component from FluidHatch to FluidTankCasingComponent & fixes its initialization to avoid the error that would happen the first time it used to be used & support late item registration
adds the fluid tank casing ghost block to FluidTank like how it was in FluidHatch
