### PR TITLE
Fix missing sleeping bag translation

### DIFF
--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -1,6 +1,9 @@
 addon: "Pylon"
 
 item:
+  sleeping_bag:
+    name: "Sleeping Bag"
+
   bandage:
     name: "Bandage"
     lore: |-


### PR DESCRIPTION
Adds the missing English translation for the Sleeping Bag.

I noticed the item did not have an entry in en.yml, causing the translation to be missing when using the item in-game.

This only adds the missing Sleeping Bag name and does not change any item behavior.